### PR TITLE
Fix service_root.py to use UUID from appliance node info

### DIFF
--- a/oneview_redfish_toolkit/blueprints/service_root.py
+++ b/oneview_redfish_toolkit/blueprints/service_root.py
@@ -44,7 +44,7 @@ def get_service_root():
         ov_client = util.get_oneview_client()
 
         # Gets serverhardware for given UUID
-        ov_info = ov_client.appliance_node_information.get_status()
+        ov_info = ov_client.appliance_node_information.get_version()
         uuid = ov_info['uuid']
 
         obj = ServiceRoot(uuid)

--- a/oneview_redfish_toolkit/tests/blueprints/test_service_root.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_service_root.py
@@ -60,7 +60,7 @@ class TestServiceRoot(unittest.TestCase):
             'message': 'appliance error',
         })
 
-        client.appliance_node_information.get_status.side_effect = e
+        client.appliance_node_information.get_version.side_effect = e
 
         response = self.app.get("/redfish/v1/")
 

--- a/oneview_redfish_toolkit/tests/blueprints/test_service_root.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_service_root.py
@@ -81,7 +81,7 @@ class TestServiceRoot(unittest.TestCase):
             'message': 'appliance error',
         })
 
-        client.appliance_node_information.get_status.side_effect = e
+        client.appliance_node_information.get_version.side_effect = e
 
         response = self.app.get("/redfish/v1/")
 
@@ -97,7 +97,7 @@ class TestServiceRoot(unittest.TestCase):
         """Tests ServiceRoot blueprint result against know value """
 
         client = mock_get_ov_client()
-        client.appliance_node_information.get_status.return_value = \
+        client.appliance_node_information.get_version.return_value = \
             {'uuid': '00000000-0000-0000-0000-000000000000'}
 
         result = self.app.get("/redfish/v1/")


### PR DESCRIPTION
get_status() was being used instead of get_version() which actually contains the UUID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hewlettpackard/oneview-redfish-toolkit/49)
<!-- Reviewable:end -->
