### PR TITLE
Adding ETag in the response header

### DIFF
--- a/oneview_redfish_toolkit/blueprints/chassis.py
+++ b/oneview_redfish_toolkit/blueprints/chassis.py
@@ -58,9 +58,11 @@ def get_chassis(uuid):
 
         if category == 'server-hardware':
             server_hardware = oneview_client.server_hardware.get(uuid)
+            etag = server_hardware['eTag']
             ch = BladeChassis(server_hardware)
         elif category == 'enclosures':
             enclosure = oneview_client.enclosures.get(uuid)
+            etag = enclosure['eTag']
             enclosure_environment_config = oneview_client.enclosures.\
                 get_environmental_configuration(uuid)
             ch = EnclosureChassis(
@@ -69,16 +71,19 @@ def get_chassis(uuid):
             )
         elif category == 'racks':
             racks = oneview_client.racks.get(uuid)
+            etag = racks['eTag']
             ch = RackChassis(racks)
         else:
             raise OneViewRedfishError('Chassis type not found')
 
         json_str = ch.serialize()
 
-        return Response(
+        response = Response(
             response=json_str,
             status=status.HTTP_200_OK,
             mimetype="application/json")
+        response.headers.add("ETag", "W/" + etag)
+        return response
     except HPOneViewException as e:
         # In case of error log exception and abort
         logging.error(e)

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -73,7 +73,7 @@ def get_computer_system(uuid):
             response=json_str,
             status=status.HTTP_200_OK,
             mimetype="application/json")
-        response.headers.add("ETag", "W/"+server_hardware['eTag'])
+        response.headers.add("ETag", "W/" + server_hardware['eTag'])
         return response
     except HPOneViewException as e:
         if e.oneview_response['errorCode'] == "RESOURCE_NOT_FOUND":

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -69,10 +69,12 @@ def get_computer_system(uuid):
         json_str = cs.serialize()
 
         # Build response and returns
-        return Response(
+        response = Response(
             response=json_str,
             status=status.HTTP_200_OK,
             mimetype="application/json")
+        response.headers.add("ETag", "W/"+server_hardware['eTag'])
+        return response
     except HPOneViewException as e:
         if e.oneview_response['errorCode'] == "RESOURCE_NOT_FOUND":
             if e.msg.find("server-hardware-types") >= 0:

--- a/oneview_redfish_toolkit/blueprints/manager.py
+++ b/oneview_redfish_toolkit/blueprints/manager.py
@@ -61,19 +61,23 @@ def get_managers(uuid):
 
         if category == 'server-hardware':
             server_hardware = oneview_client.server_hardware.get(uuid)
+            etag = server_hardware['eTag']
             manager = BladeManager(server_hardware)
         elif category == 'enclosures':
             enclosure = oneview_client.enclosures.get(uuid)
+            etag = enclosure['eTag']
             manager = EnclosureManager(enclosure, oneview_version)
         else:
             raise OneViewRedfishError('Enclosure type not found')
 
         json_str = manager.serialize()
 
-        return Response(
+        response = Response(
             response=json_str,
             status=status.HTTP_200_OK,
             mimetype="application/json")
+        response.headers.add("ETag", "W/" + etag)
+        return response
     except HPOneViewException as e:
         # In case of error log exception and abort
         logging.error(e)

--- a/oneview_redfish_toolkit/tests/blueprints/test_chassis.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_chassis.py
@@ -157,31 +157,6 @@ class TestChassis(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(self.enclosure_chassis_mockup, json_str)
-
-    @mock.patch.object(util, 'get_oneview_client')
-    def test_get_enclosure_chassis_with_etag(
-            self, get_oneview_client_mockup):
-        """"Tests EnclosureChassis and ETag response header"""
-
-        oneview_client = get_oneview_client_mockup()
-
-        oneview_client.index_resources.get_all.return_value = \
-            [{"category": "enclosures"}]
-        oneview_client.enclosures.get.return_value = self.enclosure
-        oneview_client.enclosures.get_environmental_configuration.\
-            return_value = self.enclosure_environment_configuration_mockup
-
-        # Get EnclosureChassis
-        response = self.app.get(
-            "/redfish/v1/Chassis/0000000000A66101"
-        )
-
-        json_str = response.data.decode("utf-8")
-
-        # Tests response
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual("application/json", response.mimetype)
-        self.assertEqual(self.enclosure_chassis_mockup, json_str)
         self.assertEqual(
             "{}{}".format("W/", self.enclosure["eTag"]),
             response.headers["ETag"])
@@ -303,29 +278,6 @@ class TestChassis(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(self.blade_chassis_mockup, json_str)
-
-    @mock.patch.object(util, 'get_oneview_client')
-    def test_get_blade_chassis_with_etag(
-            self, get_oneview_client_mockup):
-        """"Tests BladeChassis and ETag response header"""
-
-        oneview_client = get_oneview_client_mockup()
-
-        oneview_client.index_resources.get_all.return_value = \
-            [{"category": "server-hardware"}]
-        oneview_client.server_hardware.get.return_value = self.server_hardware
-
-        # Get BladeChassis
-        response = self.app.get(
-            "/redfish/v1/Chassis/30303437-3034-4D32-3230-313133364752"
-        )
-
-        json_str = response.data.decode("utf-8")
-
-        # Tests response
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual("application/json", response.mimetype)
-        self.assertEqual(self.blade_chassis_mockup, json_str)
         self.assertEqual(
             "{}{}".format("W/", self.server_hardware["eTag"]),
             response.headers["ETag"])
@@ -380,29 +332,6 @@ class TestChassis(unittest.TestCase):
     def test_get_rack_chassis(
             self, get_oneview_client_mockup):
         """"Tests RackChassis with a known Rack"""
-
-        oneview_client = get_oneview_client_mockup()
-
-        oneview_client.index_resources.get_all.return_value = \
-            [{"category": "racks"}]
-        oneview_client.racks.get.return_value = self.rack
-
-        # Get RackChassis
-        response = self.app.get(
-            "/redfish/v1/Chassis/2AB100LMNB"
-        )
-
-        json_str = response.data.decode("utf-8")
-
-        # Tests response
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual("application/json", response.mimetype)
-        self.assertEqual(self.rack_chassis_mockup, json_str)
-
-    @mock.patch.object(util, 'get_oneview_client')
-    def test_get_rack_chassis_with_etag(
-            self, get_oneview_client_mockup):
-        """"Tests RackChassis and ETag response header"""
 
         oneview_client = get_oneview_client_mockup()
 

--- a/oneview_redfish_toolkit/tests/blueprints/test_chassis.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_chassis.py
@@ -159,6 +159,34 @@ class TestChassis(unittest.TestCase):
         self.assertEqual(self.enclosure_chassis_mockup, json_str)
 
     @mock.patch.object(util, 'get_oneview_client')
+    def test_get_enclosure_chassis_with_etag(
+            self, get_oneview_client_mockup):
+        """"Tests EnclosureChassis and ETag response header"""
+
+        oneview_client = get_oneview_client_mockup()
+
+        oneview_client.index_resources.get_all.return_value = \
+            [{"category": "enclosures"}]
+        oneview_client.enclosures.get.return_value = self.enclosure
+        oneview_client.enclosures.get_environmental_configuration.\
+            return_value = self.enclosure_environment_configuration_mockup
+
+        # Get EnclosureChassis
+        response = self.app.get(
+            "/redfish/v1/Chassis/0000000000A66101"
+        )
+
+        json_str = response.data.decode("utf-8")
+
+        # Tests response
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqual(self.enclosure_chassis_mockup, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", self.enclosure["eTag"]),
+            response.headers["ETag"])
+
+    @mock.patch.object(util, 'get_oneview_client')
     def test_get_enclosure_not_found(self, get_oneview_client_mockup):
         """Tests EnclosureChassis with Enclosure not found"""
 
@@ -277,6 +305,32 @@ class TestChassis(unittest.TestCase):
         self.assertEqual(self.blade_chassis_mockup, json_str)
 
     @mock.patch.object(util, 'get_oneview_client')
+    def test_get_blade_chassis_with_etag(
+            self, get_oneview_client_mockup):
+        """"Tests BladeChassis and ETag response header"""
+
+        oneview_client = get_oneview_client_mockup()
+
+        oneview_client.index_resources.get_all.return_value = \
+            [{"category": "server-hardware"}]
+        oneview_client.server_hardware.get.return_value = self.server_hardware
+
+        # Get BladeChassis
+        response = self.app.get(
+            "/redfish/v1/Chassis/30303437-3034-4D32-3230-313133364752"
+        )
+
+        json_str = response.data.decode("utf-8")
+
+        # Tests response
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqual(self.blade_chassis_mockup, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", self.server_hardware["eTag"]),
+            response.headers["ETag"])
+
+    @mock.patch.object(util, 'get_oneview_client')
     def test_get_server_hardware_not_found(self, get_oneview_client_mockup):
         """Tests BladeChassis with Server Hardware not found"""
 
@@ -344,6 +398,32 @@ class TestChassis(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(self.rack_chassis_mockup, json_str)
+
+    @mock.patch.object(util, 'get_oneview_client')
+    def test_get_rack_chassis_with_etag(
+            self, get_oneview_client_mockup):
+        """"Tests RackChassis and ETag response header"""
+
+        oneview_client = get_oneview_client_mockup()
+
+        oneview_client.index_resources.get_all.return_value = \
+            [{"category": "racks"}]
+        oneview_client.racks.get.return_value = self.rack
+
+        # Get RackChassis
+        response = self.app.get(
+            "/redfish/v1/Chassis/2AB100LMNB"
+        )
+
+        json_str = response.data.decode("utf-8")
+
+        # Tests response
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqual(self.rack_chassis_mockup, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", self.rack["eTag"]),
+            response.headers["ETag"])
 
     @mock.patch.object(util, 'get_oneview_client')
     def test_get_rack_not_found(self, get_oneview_client_mockup):

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
@@ -265,47 +265,6 @@ class TestComputerSystem(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(computer_system_mockup, json_str)
-
-    @mock.patch.object(util, 'get_oneview_client')
-    def test_get_computer_system_with_etag(self, get_oneview_client_mockup):
-        """Tests ComputerSystem and ETag response header"""
-
-        # Loading server_hardware mockup value
-        with open(
-            'oneview_redfish_toolkit/mockups_oneview/ServerHardware.json'
-        ) as f:
-            server_hardware = json.load(f)
-
-        # Loading ServerHardwareTypes mockup value
-        with open(
-            'oneview_redfish_toolkit/mockups_oneview/ServerHardwareTypes.json'
-        ) as f:
-            server_hardware_types = json.load(f)
-
-        # Loading ComputerSystem mockup result
-        with open(
-            'oneview_redfish_toolkit/mockups_redfish/ComputerSystem.json'
-        ) as f:
-            computer_system_mockup = f.read()
-
-        # Create mock response
-        oneview_client = get_oneview_client_mockup()
-        oneview_client.server_hardware.get.return_value = server_hardware
-        oneview_client.server_hardware_types.get.return_value = \
-            server_hardware_types
-
-        # Get ComputerSystem
-        response = self.app.get(
-            "/redfish/v1/Systems/0303437-3034-4D32-3230-313133364752"
-        )
-
-        # Gets json from response
-        json_str = response.data.decode("utf-8")
-
-        # Tests response
-        self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual("application/json", response.mimetype)
-        self.assertEqual(computer_system_mockup, json_str)
         self.assertEqual(
             "{}{}".format("W/", server_hardware["eTag"]),
             response.headers["ETag"])

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
@@ -267,6 +267,50 @@ class TestComputerSystem(unittest.TestCase):
         self.assertEqual(computer_system_mockup, json_str)
 
     @mock.patch.object(util, 'get_oneview_client')
+    def test_get_computer_system_with_etag(self, get_oneview_client_mockup):
+        """Tests ComputerSystem and ETag response header"""
+
+        # Loading server_hardware mockup value
+        with open(
+            'oneview_redfish_toolkit/mockups_oneview/ServerHardware.json'
+        ) as f:
+            server_hardware = json.load(f)
+
+        # Loading ServerHardwareTypes mockup value
+        with open(
+            'oneview_redfish_toolkit/mockups_oneview/ServerHardwareTypes.json'
+        ) as f:
+            server_hardware_types = json.load(f)
+
+        # Loading ComputerSystem mockup result
+        with open(
+            'oneview_redfish_toolkit/mockups_redfish/ComputerSystem.json'
+        ) as f:
+            computer_system_mockup = f.read()
+
+        # Create mock response
+        oneview_client = get_oneview_client_mockup()
+        oneview_client.server_hardware.get.return_value = server_hardware
+        oneview_client.server_hardware_types.get.return_value = \
+            server_hardware_types
+
+        # Get ComputerSystem
+        response = self.app.get(
+            "/redfish/v1/Systems/0303437-3034-4D32-3230-313133364752"
+        )
+
+        # Gets json from response
+        json_str = response.data.decode("utf-8")
+
+        # Tests response
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqual(computer_system_mockup, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", server_hardware["eTag"]),
+            response.headers["ETag"])
+
+    @mock.patch.object(util, 'get_oneview_client')
     def test_change_power_state(self, mock_get_ov_client):
         """Tests change SH power state with valid power values
 

--- a/oneview_redfish_toolkit/tests/blueprints/test_manager.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_manager.py
@@ -124,6 +124,9 @@ class TestManager(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(rf_enclosure_manager, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", ov_enclosure["eTag"]),
+            response.headers["ETag"])
 
     @mock.patch.object(util, 'get_oneview_client')
     def test_get_enclosure_not_found(self, get_oneview_client_mockup):
@@ -207,6 +210,9 @@ class TestManager(unittest.TestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(blade_manager_mockup, json_str)
+        self.assertEqual(
+            "{}{}".format("W/", server_hardware["eTag"]),
+            response.headers["ETag"])
 
     @mock.patch.object(util, 'get_oneview_client')
     def test_get_server_hardware_not_found(self, get_oneview_client_mockup):


### PR DESCRIPTION
Fixed #160 

Adding ETag in the response header for computer system and chassis.