### PR TITLE
Unpin python executable from docs generation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = {posargs}
 commands = python setup.py test --coverage --testr-args='{posargs}'
 
 [testenv:docs]
-basepython=python
+#basepython=python
 deps=
     sphinx
     sphinx_rtd_theme


### PR DESCRIPTION
Choosing python has lead to docs generation error when running on Windows 7 with python 3.5.