### PR TITLE
Add debug option into the Redfish service configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
  - #222 Open scmb connection
  - #225 Fix NetworkInterface URL in NetworkInterfaceCollection
  - #227 Implements DELETE Subscription
- 
+ - #239 Add debug option in the service configuration file
+
 # New Redfish resources
  - EventService
  - EventSubscription
@@ -29,11 +30,11 @@
  - #169 New windows launcher script
  - #151 Enhances log messages with stack traces for debugging
  - #135 Perform schema validation with local resources
- - #184 Add config support to session based authentication 
+ - #184 Add config support to session based authentication
  - #197 Fix schema loading when running on Windows
  - #198 Allow user to specify a different host ip address
  - #209 Fix wrong links in XML metadata
- 
+
 # New Redfish resources
  - Storage
  - Network Interface

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -298,10 +298,24 @@ if __name__ == '__main__':
             format(ssl_type))
         exit(1)
 
+    try:
+        debug = config["redfish"]["debug"].lower()
+
+        if debug not in ('false', 'true'):
+            logging.warning(
+                "Debug option must be either \'true\' or \'false\'. "
+                "Defaulting to \'false\'.")
+            debug = False
+        else:
+            debug = (debug == "true")
+    except Exception:
+        logging.warning("Invalid debug configuration. Defaulting to \'false\'.")
+        debug = False
+
     if ssl_type == 'disabled':
-        app.run(host=host, port=port, debug=True)
+        app.run(host=host, port=port, debug=debug)
     elif ssl_type == 'adhoc':
-        app.run(host=host, port=port, debug=True, ssl_context="adhoc")
+        app.run(host=host, port=port, debug=debug, ssl_context="adhoc")
     else:
         # We should use certs file provided by the user
         ssl_cert_file = config["ssl"]["SSLCertFile"]
@@ -323,4 +337,4 @@ if __name__ == '__main__':
                 format(ssl_cert_file, ssl_key_file))
 
         ssl_context = (ssl_cert_file, ssl_key_file)
-        app.run(host=host, port=port, debug=True, ssl_context=ssl_context)
+        app.run(host=host, port=port, debug=debug, ssl_context=ssl_context)

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -299,7 +299,7 @@ if __name__ == '__main__':
         exit(1)
 
     try:
-        debug = config["redfish"]["debug"].lower()
+        debug = config["redfish"]["debug"]
 
         if debug not in ('false', 'true'):
             logging.warning(
@@ -309,7 +309,9 @@ if __name__ == '__main__':
         else:
             debug = (debug == "true")
     except Exception:
-        logging.warning("Invalid debug configuration. Defaulting to \'false\'.")
+        logging.warning(
+            "Invalid debug configuration. "
+            "Defaulting to \'false\'.")
         debug = False
 
     if ssl_type == 'disabled':

--- a/redfish.conf
+++ b/redfish.conf
@@ -6,6 +6,7 @@ xml_prettify = True
 redfish_host = 0.0.0.0
 redfish_port = 5000
 authentication_mode = session
+debug = false
 
 [oneview_config]
 ip =
@@ -29,7 +30,7 @@ countryName = US
 stateOrProvinceName = California
 localityName = Palo Alto
 organizationName = Hewlett Packard Enterprise
-#organizationalUnitName = 
+#organizationalUnitName =
 #commonName = SERVER_FQDN OR IP
 #emailAddress = Optional sever admin email
 


### PR DESCRIPTION
The debug option allows the user to decide whether the Flask HTTP server must run in debug mode or not.

Closes #236 