### PR TITLE
Adds ResourceBlocks for each Server Profile Template in the ResourceBlocks Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
  - #233 Implement ResourceBlocks
  - #234 Implement ResourceZones
  - #259 Add ResourceBlocks for each Server Profile Template in the ResourceBlocks collection
- - #280 Empty collections should not return error message
 
 # New Redfish resources
  - EventService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
  - #249 Redfish Events notification
  - #233 Implement ResourceBlocks
  - #234 Implement ResourceZones
+ - #259 Add ResourceBlocks for each Server Profile Template in the ResourceBlocks collection
+ - #280 Empty collections should not return error message
 
 # New Redfish resources
  - EventService

--- a/oneview_redfish_toolkit/api/resource_block_collection.py
+++ b/oneview_redfish_toolkit/api/resource_block_collection.py
@@ -27,7 +27,7 @@ class ResourceBlockCollection(RedfishJsonValidator):
 
     SCHEMA_NAME = 'ResourceBlockCollection'
 
-    def __init__(self, server_hardware):
+    def __init__(self, server_hardware=[], server_profile_templates=[]):
         """ResourceBlockCollection constructor
 
             Populates self.redfish with a hardcoded ResourceBlockCollection
@@ -36,12 +36,12 @@ class ResourceBlockCollection(RedfishJsonValidator):
 
         super().__init__(self.SCHEMA_NAME)
 
-        self.server_hardware = server_hardware
+        self.members = server_hardware + server_profile_templates
 
         self.redfish["@odata.type"] = \
             "#ResourceBlockCollection.ResourceBlockCollection"
         self.redfish["Name"] = "Resource Block Collection"
-        self.redfish["Members@odata.count"] = len(server_hardware)
+        self.redfish["Members@odata.count"] = len(self.members)
         self.redfish["Members"] = list()
         self._set_redfish_members()
         self.redfish["@odata.context"] = \
@@ -59,10 +59,11 @@ class ResourceBlockCollection(RedfishJsonValidator):
             ResourceBlock.
         """
 
-        for server_hardware in self.server_hardware:
+        for item in self.members:
             resource_block = dict()
 
+            uuid = item.get('uuid') or item["uri"].split("/")[-1]
             resource_block["@odata.id"] = "/redfish/v1/CompositionService/" \
-                "ResourceBlocks/" + server_hardware["uuid"]
+                "ResourceBlocks/" + uuid
 
             self.redfish["Members"].append(resource_block)

--- a/oneview_redfish_toolkit/blueprints/resource_block_collection.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block_collection.py
@@ -22,8 +22,6 @@ from flask import g
 from flask import Response
 from flask_api import status
 
-from oneview_redfish_toolkit.api.errors \
-    import OneViewRedfishResourceNotFoundError
 from oneview_redfish_toolkit.api.resource_block_collection \
     import ResourceBlockCollection
 
@@ -47,13 +45,10 @@ def get_resource_block_collection():
     try:
         # Gets all server hardware
         server_hardware_list = g.oneview_client.server_hardware.get_all()
-
-        if not server_hardware_list:
-            raise OneViewRedfishResourceNotFoundError(
-                "server-hardware-list", "Resource")
+        server_profile_template_list = g.oneview_client.server_profile_templates.get_all()
 
         # Build ResourceBlockCollection object and validates it
-        cc = ResourceBlockCollection(server_hardware_list)
+        cc = ResourceBlockCollection(server_hardware_list, server_profile_template_list)
 
         # Build redfish json
         json_str = cc.serialize()
@@ -63,10 +58,6 @@ def get_resource_block_collection():
             response=json_str,
             status=status.HTTP_200_OK,
             mimetype="application/json")
-    except OneViewRedfishResourceNotFoundError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
     except Exception as e:
         # In case of error print exception and abort
         logging.exception('Unexpected error: {}'.format(e))

--- a/oneview_redfish_toolkit/blueprints/resource_block_collection.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block_collection.py
@@ -45,10 +45,12 @@ def get_resource_block_collection():
     try:
         # Gets all server hardware
         server_hardware_list = g.oneview_client.server_hardware.get_all()
-        server_profile_template_list = g.oneview_client.server_profile_templates.get_all()
+        server_profile_template_list = g.oneview_client.\
+            server_profile_templates.get_all()
 
         # Build ResourceBlockCollection object and validates it
-        cc = ResourceBlockCollection(server_hardware_list, server_profile_template_list)
+        cc = ResourceBlockCollection(server_hardware_list,
+                                     server_profile_template_list)
 
         # Build redfish json
         json_str = cc.serialize()

--- a/oneview_redfish_toolkit/mockups/redfish/ResourceBlockCollection.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ResourceBlockCollection.json
@@ -1,7 +1,7 @@
 {
     "@odata.type": "#ResourceBlockCollection.ResourceBlockCollection",
     "Name": "Resource Block Collection",
-    "Members@odata.count": 24,
+    "Members@odata.count": 27,
     "Members": [
         {
             "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/30373737-3237-4D32-3230-313531354752"
@@ -74,6 +74,15 @@
         },
         {
             "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/30303437-3034-4D32-3230-313132314752"
+        },
+        {
+            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0"
+        },
+        {
+            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/71f6210a-6648-439f-bf24-1cecb94fbfde"
+        },
+        {
+            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/75871d70-789e-4cf9-8bc8-6f4d73193578"
         }
     ],
     "@odata.context": "/redfish/v1/$metadata#ResourceBlockCollection.ResourceBlockCollection",

--- a/oneview_redfish_toolkit/mockups/redfish/ResourceBlockCollectionEmpty.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ResourceBlockCollectionEmpty.json
@@ -1,0 +1,8 @@
+{
+    "@odata.type": "#ResourceBlockCollection.ResourceBlockCollection",
+    "Name": "Resource Block Collection",
+    "Members@odata.count": 0,
+    "Members": [],
+    "@odata.context": "/redfish/v1/$metadata#ResourceBlockCollection.ResourceBlockCollection",
+    "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks"
+}

--- a/oneview_redfish_toolkit/tests/api/test_resource_block_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_resource_block_collection.py
@@ -84,14 +84,11 @@ class TestResourceBlockCollection(unittest.TestCase):
         self.assertEqual(self.resource_block_collection_mockup, result)
 
     def test_serialize_empty_result(self):
-        expected_result = {
-            "@odata.type": "#ResourceBlockCollection.ResourceBlockCollection",
-            "Name": "Resource Block Collection",
-            "Members@odata.count": 0,
-            "Members": [],
-            "@odata.context": "/redfish/v1/$metadata#ResourceBlockCollection.ResourceBlockCollection",
-            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks"
-        }
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish/'
+            'ResourceBlockCollectionEmpty.json'
+        ) as f:
+            expected_result = json.load(f)
 
         # Tests the serialize function result against empty list result
         resource_block_collection = ResourceBlockCollection()

--- a/oneview_redfish_toolkit/tests/api/test_resource_block_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_resource_block_collection.py
@@ -42,6 +42,13 @@ class TestResourceBlockCollection(unittest.TestCase):
         ) as f:
             self.server_hardware_list = json.load(f)
 
+        # Loading ServerProfileTemplate list mockup value
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/'
+            'ServerProfileTemplates.json'
+        ) as f:
+            self.server_profile_template_list = json.load(f)
+
         # Loading ResourceBlockCollection result mockup
         with open(
             'oneview_redfish_toolkit/mockups/redfish/'
@@ -53,7 +60,7 @@ class TestResourceBlockCollection(unittest.TestCase):
         # Tests if class is correctly instantiated and validated
         try:
             resource_block_collection = ResourceBlockCollection(
-                self.server_hardware_list)
+                self.server_hardware_list, self.server_profile_template_list)
         except Exception as e:
             self.fail("Failed to instantiate ResourceBlockCollection class."
                       " Error: {}".format(e))
@@ -64,7 +71,7 @@ class TestResourceBlockCollection(unittest.TestCase):
         # Tests the serialize function result against known result
         try:
             resource_block_collection = ResourceBlockCollection(
-                self.server_hardware_list)
+                self.server_hardware_list, self.server_profile_template_list)
         except Exception as e:
             self.fail("Failed to instantiate ResourceBlockCollection class."
                       " Error: {}".format(e))
@@ -75,3 +82,19 @@ class TestResourceBlockCollection(unittest.TestCase):
             self.fail("Failed to serialize. Error: {}".format(e))
 
         self.assertEqual(self.resource_block_collection_mockup, result)
+
+    def test_serialize_empty_result(self):
+        expected_result = {
+            "@odata.type": "#ResourceBlockCollection.ResourceBlockCollection",
+            "Name": "Resource Block Collection",
+            "Members@odata.count": 0,
+            "Members": [],
+            "@odata.context": "/redfish/v1/$metadata#ResourceBlockCollection.ResourceBlockCollection",
+            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks"
+        }
+
+        # Tests the serialize function result against empty list result
+        resource_block_collection = ResourceBlockCollection()
+        result = json.loads(resource_block_collection.serialize())
+
+        self.assertEqual(expected_result, result)

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block_collection.py
@@ -98,7 +98,8 @@ class TestResourceBlockCollection(unittest.TestCase):
             server_hardware_list = json.load(f)
 
         with open(
-            'oneview_redfish_toolkit/mockups/oneview/ServerProfileTemplates.json'
+            'oneview_redfish_toolkit/mockups/oneview/'
+            'ServerProfileTemplates.json'
         ) as f:
             server_profile_template_list = json.load(f)
 
@@ -140,14 +141,11 @@ class TestResourceBlockCollection(unittest.TestCase):
         # Gets json from response
         result = json.loads(response.data.decode("utf-8"))
 
-        expected_result = {
-            "@odata.type": "#ResourceBlockCollection.ResourceBlockCollection",
-            "Name": "Resource Block Collection",
-            "Members@odata.count": 0,
-            "Members": [],
-            "@odata.context": "/redfish/v1/$metadata#ResourceBlockCollection.ResourceBlockCollection",
-            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks"
-        }
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish/'
+            'ResourceBlockCollectionEmpty.json'
+        ) as f:
+            expected_result = json.load(f)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)


### PR DESCRIPTION
This commit:
- Adds ResourceBlocks for each Server Profile Template in the ResourceBlocks Collection
- Removes the 404 error from ResourceBlocks Collection api when the collection is empty
- Increases tests to cover server profile template in the ResourceBlocks Collection api

Closes #259 