### PR TITLE
Implement Storage ResourceBlock 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - #300 Include Storage Resource Blocks into Resource Blocks collection
  - #261 Implement Network Resource Block
  - #298 Include Network Resource Blocks into Resource Blocks collection
+ - #293 Implement Storage ResourceBlock
 
 # New Redfish resources
  - EventService

--- a/oneview_redfish_toolkit/api/storage_resource_block.py
+++ b/oneview_redfish_toolkit/api/storage_resource_block.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oneview_redfish_toolkit.api.resource_block import ResourceBlock
+from oneview_redfish_toolkit.api import status_mapping
+
+
+class StorageResourceBlock(ResourceBlock):
+    """Creates a ResourceBlock Redfish dict for Storage Drive
+
+        Populates self.redfish with Drive data retrieved from OneView.
+    """
+
+    def __init__(self, drive):
+        """StorageResourceBlock constructor
+
+            Populates self.redfish with the contents of drive
+
+            Args:
+                drive: OneView Drive dict
+        """
+        uuid = drive["uri"].split("/")[-1]
+        super().__init__(uuid, drive)
+
+        self.redfish["ResourceBlockType"] = ["Storage"]
+        self.redfish["Status"] = status_mapping.STATUS_MAP.get(drive["status"])
+
+        if drive["attributes"]["available"]:
+            compositState = "Unused"
+        else:
+            compositState = "Composed"
+
+        self.redfish["CompositionStatus"]["CompositionState"] = compositState
+
+        self.redfish["Storage"] = [
+            {
+                "@odata.id": self.redfish["@odata.id"] + "/Storage/1"
+            }
+        ]
+
+        self._validate()

--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -32,6 +32,8 @@ from oneview_redfish_toolkit.api.server_hardware_resource_block \
     import ServerHardwareResourceBlock
 from oneview_redfish_toolkit.api.server_profile_template_resource_block \
     import ServerProfileTemplateResourceBlock
+from oneview_redfish_toolkit.api.storage_resource_block \
+    import StorageResourceBlock
 from oneview_redfish_toolkit.blueprints.util.response_builder \
     import ResponseBuilder
 
@@ -62,11 +64,10 @@ def get_resource_block(uuid):
                 ServerProfileTemplateResourceBlock(uuid, resource)
 
         elif category == "drives":
-            # TODO(galeno) Add support for storage resource blocks (OV drives)
-            raise OneViewRedfishError('Resource block type not found')
+            resource_block = StorageResourceBlock(resource)
 
         else:
-            raise OneViewRedfishError('Resource block type not found')
+            raise OneViewRedfishError('Resource block not found')
 
         return ResponseBuilder.success(
             resource_block,

--- a/oneview_redfish_toolkit/mockups/oneview/Drive.json
+++ b/oneview_redfish_toolkit/mockups/oneview/Drive.json
@@ -1,0 +1,25 @@
+{
+    "type": "IndexResourceV300",
+    "name": "Drive 1",
+    "description": null,
+    "attributes": {
+        "capacityInGB": "100",
+        "isSanitizable": "Supported",
+        "interfaceType": "SATA",
+        "driveEnclosureUri": "/rest/drive-enclosures/SN123100",
+        "available": "yes",
+        "mediaType": "SSD",
+        "isPredictiveFailDrive": "no"
+    },
+    "multiAttributes": {},
+    "ownerId": "dfrm",
+    "state": null,
+    "status": "OK",
+    "created": "2018-04-10T19:51:24.894Z",
+    "modified": "2018-06-20T07:29:45.410Z",
+    "eTag": "2018-06-20T07:29:45.410Z",
+    "category": "drives",
+    "uri": "/rest/drives/c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e",
+    "applianceId": "c9ba5ca4-c1f8-48c7-9798-1e8b8897ef50",
+    "scopeUris": null
+}

--- a/oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json
+++ b/oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#ResourceBlock.v1_1_0.ResourceBlock",
+    "Id": "c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e",
+    "Name": "Drive 1",
+    "ResourceBlockType": [
+        "Storage"
+    ],
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "CompositionStatus": {
+        "CompositionState": "Unused"
+    },
+    "Storage": [
+        {
+            "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e/Storage/1"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#ResourceBlock.ResourceBlock",
+    "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e"
+}

--- a/oneview_redfish_toolkit/tests/api/test_storage_resource_block.py
+++ b/oneview_redfish_toolkit/tests/api/test_storage_resource_block.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+
+from oneview_redfish_toolkit.api.storage_resource_block import \
+    StorageResourceBlock
+from oneview_redfish_toolkit.tests.base_test import BaseTest
+
+
+class TestStorageResourceBlock(BaseTest):
+    """Tests for StorageResourceBlock class"""
+
+    @classmethod
+    def setUpClass(self):
+        """Tests preparation"""
+
+        super(TestStorageResourceBlock, self).setUpClass()
+
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish'
+            '/StorageResourceBlock.json'
+        ) as f:
+            self.resource_block_mockup = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/Drive.json'
+        ) as f:
+            self.drive = json.load(f)
+
+    def test_class_instantiation(self):
+        # Tests if class is correctly instantiated and validated
+        resource_block = StorageResourceBlock(self.drive)
+
+        self.assertIsInstance(resource_block, StorageResourceBlock)
+
+    def test_serialize(self):
+        # Tests the serialize function result against known result
+        resource_block = StorageResourceBlock(self.drive)
+        result = json.loads(resource_block.serialize())
+
+        self.assertEqual(self.resource_block_mockup, result)


### PR DESCRIPTION
- Handles Oneview's Drive as a resource block and return a redfish object with Storage Resource Block information when you request /redfish/v1/CompositionService/ResourceBlocks/uuid-of-oneview's-drive.
- Changes and adds unit tests to blueprints/test_resource_block .py and api/test_storage_resource_block.py

PS.: Links inside redfish Storage Resource Block object are missing, it will be included in another task.

Closes #293 