### PR TITLE
Include Storage resource blocks in a Resource Zone

### DIFF
--- a/oneview_redfish_toolkit/blueprints/zone.py
+++ b/oneview_redfish_toolkit/blueprints/zone.py
@@ -48,6 +48,9 @@ def get_zone(uuid):
         .get_available_targets(enclosureGroupUri=encl_group_uri,
                                serverHardwareTypeUri=sh_type_uri)
 
-    zone_data = Zone(profile_template, available_targets)
+    drives = g.oneview_client.index_resources \
+        .get_all(category="drives", count=10000)
+
+    zone_data = Zone(profile_template, available_targets, drives)
 
     return ResponseBuilder.success(zone_data)

--- a/oneview_redfish_toolkit/mockups/oneview/ServerProfileTemplate.json
+++ b/oneview_redfish_toolkit/mockups/oneview/ServerProfileTemplate.json
@@ -1,6 +1,21 @@
 {
   "localStorage": {
-    "controllers": [],
+    "controllers": [
+      {
+        "deviceSlot": "Mezz 1",
+        "mode":"HBA",
+        "initialize": true,
+        "driveWriteCache": "Unmanaged",
+        "logicalDrives": null
+      },
+      {
+        "deviceSlot": "Embedded",
+        "mode": "HBA",
+        "initialize": true,
+        "driveWriteCache": "Unmanaged",
+        "logicalDrives": null
+      }
+    ],
     "sasLogicalJBODs": [
       {
         "deviceSlot": "Mezz 1",

--- a/oneview_redfish_toolkit/mockups/redfish/ZoneWithoutDrives.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ZoneWithoutDrives.json
@@ -10,21 +10,6 @@
         "ResourceBlocks": [
             {
                 "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/30303437-3034-4D32-3230-313131324752"
-            },
-            {
-                "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/84d382aa-33fd-4447-a0ef-5d96bb34b345"
-            },
-            {
-                "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/53bd734f-19fe-42fe-a8ef-3f1a83b4e5c1"
-            },
-            {
-                "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/b102f715-84b1-4157-ba8d-639574e0aedc"
-            },
-            {
-                "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/ebd096fe-c036-40a4-bbff-5397ed0c2e6a"
-            },
-            {
-                "@odata.id": "/redfish/v1/CompositionService/ResourceBlocks/d8b142ba-6762-470d-9082-0e53d0499303"
             }
         ]
     },

--- a/oneview_redfish_toolkit/tests/api/test_zone.py
+++ b/oneview_redfish_toolkit/tests/api/test_zone.py
@@ -43,6 +43,7 @@ class TestZone(BaseTest):
         zone_without_drives_mockup = json.load(f)
 
     def test_serialize(self):
+        """Tests if after serialize Zone the result is as expected"""
         zone = Zone(self.server_profile_template,
                     self.available_targets,
                     self.drives)
@@ -52,6 +53,7 @@ class TestZone(BaseTest):
 
     def test_drives_as_links_when_storage_controllers_are_not_configured(
             self):
+        """Tests if Drive Resource blocks is empty when Storage Controllers are not configured"""
         profile_template = copy.deepcopy(self.server_profile_template)
         profile_template["localStorage"]["controllers"] = []
 
@@ -63,6 +65,7 @@ class TestZone(BaseTest):
         self.assertEqual(self.zone_without_drives_mockup, result)
 
     def test_drives_as_links_when_storage_controller_is_embedded(self):
+        """Tests if Drive Resource blocks is empty when Storage Controllers are not configured properly for Redfish"""
         profile_template = copy.deepcopy(self.server_profile_template)
         profile_template["localStorage"]["controllers"] = [{
             "deviceSlot": "Embedded",

--- a/oneview_redfish_toolkit/tests/api/test_zone.py
+++ b/oneview_redfish_toolkit/tests/api/test_zone.py
@@ -44,6 +44,7 @@ class TestZone(BaseTest):
 
     def test_serialize(self):
         """Tests if after serialize Zone the result is as expected"""
+
         zone = Zone(self.server_profile_template,
                     self.available_targets,
                     self.drives)
@@ -53,7 +54,12 @@ class TestZone(BaseTest):
 
     def test_drives_as_links_when_storage_controllers_are_not_configured(
             self):
-        """Tests if Drive Resource blocks is empty when Storage Controllers are not configured"""
+        """Tests Drives as Links when not configured
+
+            Tests if Drive Resource blocks is empty when Storage Controllers
+            are not configured
+        """
+
         profile_template = copy.deepcopy(self.server_profile_template)
         profile_template["localStorage"]["controllers"] = []
 
@@ -65,7 +71,12 @@ class TestZone(BaseTest):
         self.assertEqual(self.zone_without_drives_mockup, result)
 
     def test_drives_as_links_when_storage_controller_is_embedded(self):
-        """Tests if Drive Resource blocks is empty when Storage Controllers are not configured properly for Redfish"""
+        """Tests Drives as Links when not configured properly
+
+            Tests if Drive Resource blocks is empty when Storage Controllers
+            are not configured properly for Redfish
+        """
+
         profile_template = copy.deepcopy(self.server_profile_template)
         profile_template["localStorage"]["controllers"] = [{
             "deviceSlot": "Embedded",

--- a/oneview_redfish_toolkit/tests/blueprints/test_zone.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_zone.py
@@ -63,6 +63,10 @@ class TestZone(BaseTest):
         ) as f:
             available_targets = json.load(f)
 
+        with open('oneview_redfish_toolkit/mockups/oneview/'
+                  'Drives.json') as f:
+            drives = json.load(f)
+
         with open(
             'oneview_redfish_toolkit/mockups/redfish/Zone.json'
         ) as f:
@@ -72,6 +76,8 @@ class TestZone(BaseTest):
             .return_value = server_profile_template
         g_mock.oneview_client.server_profiles.get_available_targets\
             .return_value = available_targets
+        g_mock.oneview_client.index_resources.get_all\
+            .return_value = drives
 
         response = self.app.get(
             "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3"


### PR DESCRIPTION
- Storage Resource Blocks are available only if storage controller is configured and is not Embedded
- Adds unit tests to cover the scenario above

Ps.: This PR closes 2 issues (#309  and #299), but that issues will be put on CHANGELOG only after the Sprint to avoid merge problems.

Closes #299 
Closes #309  