### PR TITLE
Migrate to stestr unit test library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ cover/
 nosetests.xml
 .testrepository
 .venv
+.stestr
 
 # Translations
 *.mo

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${TESTS_DIR:-./oneview_redfish_toolkit/tests/}
+top_dir=./

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,7 +1,0 @@
-[DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
-             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
-             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 hacking>=0.12.0,<0.13 # Apache-2.0 - test pep8
-oslotest>=1.10.0 # Apache-2.0 - test py35
+oslotest>=3.2.0 # Apache-2.0 - test py35
+stestr>=1.0.0
+coverage!=4.4,>=4.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,10 @@ install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstac
 setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning
+   TESTS_DIR=./oneview_redfish_toolkit/tests/
 deps = -r{toxinidir}/test-requirements.txt
-whitelist_externals = rm
 commands =
-    rm -f .testrepository/times.dbm
-    python setup.py test --slowest --testr-args='{posargs}'
+    stestr run {posargs}
 
 [testenv:pep8]
 commands = flake8 {posargs}


### PR DESCRIPTION
@adriane-cardozo as I said, I took a look on the latest changes on unit test facilities in http://github.com/openstack/ironic and noticed they migrated to stestr unit test runner. I performed the same migration the the build turned ok again. As you already fix it in another way (updating oslo), I will leave this here only for reference in case you need to perform this migration in a near future.

PS: on the upper-constraints reference on tox.ini, I am really sorry for that! When starting the project, we used https://github.com/openstack-dev/cookiecutter as a template base as it was the best option at the moment. So we stripped (almost) everything openstack related... my bad!

Closes #321 