### PR TITLE
Adding reset actions for Chassis with Server Hardware type

### DIFF
--- a/oneview_redfish_toolkit/api/blade_chassis.py
+++ b/oneview_redfish_toolkit/api/blade_chassis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -16,6 +16,8 @@
 
 import collections
 from oneview_redfish_toolkit.api.chassis import Chassis
+from oneview_redfish_toolkit.api.util.power_option import \
+    RESET_ALLOWABLE_VALUES_LIST
 
 
 class BladeChassis(Chassis):
@@ -59,5 +61,15 @@ class BladeChassis(Chassis):
         self.redfish["NetworkAdapters"]["@odata.id"] = \
             "/redfish/v1/Chassis/" + server_hardware["uuid"] + \
             "/NetworkAdapters/"
+        self.redfish["Actions"] = collections.OrderedDict()
+        self.redfish["Actions"]["#Chassis.Reset"] = \
+            collections.OrderedDict()
+        self.redfish["Actions"]["#Chassis.Reset"]["target"] = \
+            "/redfish/v1/Chassis" + "/" + \
+            server_hardware["uuid"] + \
+            "/Actions/Chassis.Reset"
+        self.redfish["Actions"]["#Chassis.Reset"][
+            "ResetType@Redfish.AllowableValues"] = \
+            RESET_ALLOWABLE_VALUES_LIST
 
         self._validate()

--- a/oneview_redfish_toolkit/api/util/power_option.py
+++ b/oneview_redfish_toolkit/api/util/power_option.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+from oneview_redfish_toolkit.api.errors import OneViewRedfishError
+
+
+RESET_ALLOWABLE_VALUES_LIST = ["On", "ForceOff", "GracefulShutdown",
+                               "GracefulRestart", "ForceRestart", "Nmi",
+                               "ForceOn", "PushPowerButton"]
+POWER_STATE_MAP = {
+    "On": {
+        "powerState": "On",
+    },
+    "ForceOff": {
+        "powerState": "Off",
+        "powerControl": "PressAndHold"
+    },
+    "GracefulShutdown": {
+        "powerState": "Off",
+        "powerControl": "MomentaryPress"
+    },
+    "GracefulRestart": {
+        "powerState": "On",
+        "powerControl": "Reset"
+    },
+    "ForceRestart": {
+        "powerState": "On",
+        "powerControl": "ColdBoot"
+    },
+    "PushPowerButton": {
+        "powerControl": "MomentaryPress"
+    }
+}
+
+
+class OneViewPowerOption(object):
+
+    @staticmethod
+    def get_oneview_power_configuration(server_hardware, reset_type):
+        """Maps Redfish's power options to OneView's power option
+
+            Maps the known Redfish power options to OneView Power option.
+            If a unknown power option shows up it will raise an Exception.
+
+            Args:
+                server_hardware: List containing all Oneview's server
+                hardwares.
+                reset_type: Redfish power option.
+
+            Returns:
+                dict: Dict with OneView power configuration.
+
+            Exception:
+                OneViewRedfishError: raises an exception if
+                reset_type is an unmapped value.
+        """
+
+        if reset_type == "ForceOn" or reset_type == "Nmi":
+            raise OneViewRedfishError({
+                "errorCode": "NOT_IMPLEMENTED",
+                "message": "{} not mapped to OneView".format(reset_type)})
+
+        try:
+            power_state_map = POWER_STATE_MAP[reset_type]
+        except Exception:
+            raise OneViewRedfishError({
+                "errorCode": "INVALID_INFORMATION",
+                "message": "There is no mapping for {} on the OneView".format(
+                    reset_type
+                )})
+
+        if reset_type == "PushPowerButton":
+            if server_hardware["powerState"] == "On":
+                power_state_map["powerState"] = "Off"
+            else:
+                power_state_map["powerState"] = "On"
+
+        return power_state_map

--- a/oneview_redfish_toolkit/blueprints/chassis.py
+++ b/oneview_redfish_toolkit/blueprints/chassis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -21,6 +21,7 @@ import logging
 from flask import abort
 from flask import Blueprint
 from flask import g
+from flask import request
 from flask import Response
 from flask_api import status
 from hpOneView.exceptions import HPOneViewException
@@ -30,6 +31,9 @@ from oneview_redfish_toolkit.api.blade_chassis import BladeChassis
 from oneview_redfish_toolkit.api.enclosure_chassis import EnclosureChassis
 from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.rack_chassis import RackChassis
+from oneview_redfish_toolkit.api.util.power_option import OneViewPowerOption
+from oneview_redfish_toolkit.blueprints.util.response_builder import \
+    ResponseBuilder
 
 chassis = Blueprint("chassis", __name__)
 
@@ -44,53 +48,102 @@ def get_chassis(uuid):
         Returns:
             JSON: JSON with Chassis.
     """
+    resource_index = g.oneview_client.index_resources.get_all(
+        filter='uuid=' + uuid
+    )
+    category = resource_index[0]["category"]
+
+    if category == 'server-hardware':
+        server_hardware = g.oneview_client.server_hardware.get(uuid)
+        etag = server_hardware['eTag']
+        ch = BladeChassis(server_hardware)
+    elif category == 'enclosures':
+        enclosure = g.oneview_client.enclosures.get(uuid)
+        etag = enclosure['eTag']
+        enclosure_environment_config = g.oneview_client.enclosures. \
+            get_environmental_configuration(uuid)
+        ch = EnclosureChassis(
+            enclosure,
+            enclosure_environment_config
+        )
+    elif category == 'racks':
+        racks = g.oneview_client.racks.get(uuid)
+        etag = racks['eTag']
+        ch = RackChassis(racks)
+
+    return ResponseBuilder.success(ch, {"ETag": "W/" + etag})
+
+
+@chassis.route("/redfish/v1/Chassis/<uuid>/"
+               "Actions/Chassis.Reset", methods=["POST"])
+def change_server_hardware_power_state(uuid):
+    """Change the Oneview power state for a specific Server hardware.
+
+        Return ResetType Chassis redfish JSON for a
+        given chassis UUID.
+        Logs exception of any error and return abort.
+
+        Returns:
+            JSON: Redfish JSON with Chassis ResetType.
+
+        Exceptions:
+            q: When some OneView resource was not found.
+            return abort(404)
+
+            OneViewRedfishError: When occurs a power state mapping error.
+            return abort(400)
+
+            Exception: Unexpected error.
+            return abort(500)
+    """
     try:
+        try:
+            reset_type = request.get_json()["ResetType"]
+        except Exception:
+            raise OneViewRedfishError(
+                {"errorCode": "INVALID_INFORMATION",
+                 "message": "Invalid JSON key"})
+
         resource_index = g.oneview_client.index_resources.get_all(
             filter='uuid=' + uuid
         )
 
-        if resource_index:
-            category = resource_index[0]["category"]
-        else:
-            raise OneViewRedfishError('Cannot find Index resource')
-
+        category = resource_index[0]["category"]
         if category == 'server-hardware':
-            server_hardware = g.oneview_client.server_hardware.get(uuid)
-            etag = server_hardware['eTag']
-            ch = BladeChassis(server_hardware)
-        elif category == 'enclosures':
-            enclosure = g.oneview_client.enclosures.get(uuid)
-            etag = enclosure['eTag']
-            enclosure_environment_config = g.oneview_client.enclosures.\
-                get_environmental_configuration(uuid)
-            ch = EnclosureChassis(
-                enclosure,
-                enclosure_environment_config
-            )
-        elif category == 'racks':
-            racks = g.oneview_client.racks.get(uuid)
-            etag = racks['eTag']
-            ch = RackChassis(racks)
-        else:
-            raise OneViewRedfishError('Chassis type not found')
+            # Gets ServerHardware for given UUID
+            sh = g.oneview_client.server_hardware.get(uuid)
 
-        json_str = ch.serialize()
+            # Gets power configuration based on OneView pattern
+            oneview_power_configuration = \
+                OneViewPowerOption.get_oneview_power_configuration(
+                    sh, reset_type
+                )
 
-        response = Response(
-            response=json_str,
-            status=status.HTTP_200_OK,
-            mimetype="application/json")
-        response.headers.add("ETag", "W/" + etag)
-        return response
+            # Changes the ServerHardware power state
+            g.oneview_client.server_hardware.update_power_state(
+                oneview_power_configuration, uuid)
+
+            return Response(
+                response='{"ResetType": "%s"}' % reset_type,
+                status=status.HTTP_200_OK,
+                mimetype='application/json')
     except HPOneViewException as e:
         # In case of error log exception and abort
         logging.exception(e)
-        abort(status.HTTP_404_NOT_FOUND)
+
+        if e.oneview_response['errorCode'] == "RESOURCE_NOT_FOUND":
+            abort(status.HTTP_404_NOT_FOUND, "Server hardware not found")
+        else:
+            abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     except OneViewRedfishError as e:
         # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, "Chassis not found")
+        logging.exception('Mapping error: {}'.format(e))
+
+        if e.msg["errorCode"] == "NOT_IMPLEMENTED":
+            abort(status.HTTP_501_NOT_IMPLEMENTED, e.msg['message'])
+        else:
+            abort(status.HTTP_400_BAD_REQUEST, e.msg['message'])
 
     except Exception as e:
         # In case of error log exception and abort

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -31,6 +31,7 @@ from hpOneView.resources.task_monitor import TASK_ERROR_STATES
 from oneview_redfish_toolkit.api.capabilities_object import CapabilitiesObject
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
 from oneview_redfish_toolkit.api.errors import OneViewRedfishError
+from oneview_redfish_toolkit.api.util.power_option import OneViewPowerOption
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
 
@@ -115,7 +116,8 @@ def change_power_state(uuid):
         cs = ComputerSystem(sh, sht)
 
         oneview_power_configuration = \
-            cs.get_oneview_power_configuration(reset_type)
+            OneViewPowerOption.get_oneview_power_configuration(
+                cs.server_hardware, reset_type)
 
         # Changes the ServerHardware power state
         g.oneview_client.server_hardware.update_power_state(

--- a/oneview_redfish_toolkit/mockups/redfish/BladeChassis.json
+++ b/oneview_redfish_toolkit/mockups/redfish/BladeChassis.json
@@ -34,5 +34,20 @@
     "IndicatorLED": "Off",
     "NetworkAdapters": {
         "@odata.id": "/redfish/v1/Chassis/30303437-3034-4D32-3230-313133364752/NetworkAdapters/"
+    },
+    "Actions": {
+        "#Chassis.Reset": {
+            "target": "/redfish/v1/Chassis/30303437-3034-4D32-3230-313133364752/Actions/Chassis.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ]
+        }
     }
 }

--- a/oneview_redfish_toolkit/tests/api/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/api/test_computer_system.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -18,7 +18,6 @@ import json
 from jsonschema.exceptions import ValidationError
 
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.tests.base_test import BaseTest
 
 
@@ -85,14 +84,3 @@ class TestComputerSystem(BaseTest):
             self.fail("Failed to serialize. Error: ".format(e))
 
         self.assertEqual(self.computer_system_mockup, result)
-
-    def test_get_oneview_power_configuration(self):
-        # Tests invalid mapping values of power state
-        #
-        obj = ComputerSystem(self.server_hardware, self.server_hardware_types)
-
-        self.assertRaises(OneViewRedfishError, obj.
-                          get_oneview_power_configuration, "ForceOn")
-
-        self.assertRaises(OneViewRedfishError, obj.
-                          get_oneview_power_configuration, "INVALID")


### PR DESCRIPTION
 - Adding implementation on Chassis to supports Reset actions by using POST request
 - Replacing method to handle power option parser between redfish and oneview to the util package
 - Updating computer system unit tests to use power option handle from util
 - Creating unit tests for Reset actions on Chassis

Closes https://github.com/HewlettPackard/oneview-redfish-toolkit/issues/317