### PR TITLE
Fixes endpoint to reset a server hardware of a System

### DIFF
--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -128,7 +128,7 @@ def change_power_state(uuid):
 
         # Changes the ServerHardware power state
         g.oneview_client.server_hardware.update_power_state(
-            oneview_power_configuration, uuid)
+            oneview_power_configuration, sh["uuid"])
 
         return Response(
             response='{"ResetType": "%s"}' % reset_type,

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
@@ -344,6 +344,12 @@ class TestComputerSystem(BaseFlaskTest):
 
             self.assertEqual(json_str, '{"ResetType": "%s"}' % reset_type)
 
+        g.oneview_client.server_hardware.update_power_state \
+            .assert_called_with({
+                'powerControl': 'MomentaryPress',
+                'powerState': 'Off'
+            }, "30303437-3034-4D32-3230-313133364752")
+
     @mock.patch.object(computer_system, 'g')
     def test_change_power_state_invalid_value(self, g):
         """Tests change SH power state with invalid power value"""


### PR DESCRIPTION
- The uuid used to reset was changed from server profile to server hardware fixing the error

Closes #335 