### PR TITLE
Update CompositionState of Computer System Resource Block

### DIFF
--- a/oneview_redfish_toolkit/api/server_hardware_resource_block.py
+++ b/oneview_redfish_toolkit/api/server_hardware_resource_block.py
@@ -52,9 +52,10 @@ class ServerHardwareResourceBlock(ResourceBlock):
         self.redfish["ResourceBlockType"] = ["ComputerSystem"]
 
         self.redfish["CompositionStatus"]["SharingCapable"] = False
-        self.redfish["CompositionStatus"]["CompositionState"] = status_mapping.\
-            get_redfish_composition_state(self.server_hardware)
 
+        composition_state = self._get_composition_state()
+        self.redfish["CompositionStatus"]["CompositionState"] = \
+            composition_state
         self.redfish["Status"] = collections.OrderedDict()
         state, health = status_mapping.\
             get_redfish_server_hardware_status_struct(server_hardware)
@@ -65,6 +66,23 @@ class ServerHardwareResourceBlock(ResourceBlock):
         self._fill_links()
 
         self._validate()
+
+    def _get_composition_state(self):
+        composition_state = status_mapping.\
+            get_redfish_composition_state(self.server_hardware)
+
+        if not composition_state:
+            composition_state = self._get_server_profile_state()
+
+        return composition_state
+
+    def _get_server_profile_state(self):
+        server_profile_uri = self.server_hardware["serverProfileUri"]
+
+        if server_profile_uri:
+            return status_mapping.COMPOSITION_STATE_MAPPING["ProfileApplied"]
+        else:
+            return status_mapping.COMPOSITION_STATE_MAPPING["NoProfileApplied"]
 
     def _fill_computer_system(self):
         self.redfish["ComputerSystems"] = list()

--- a/oneview_redfish_toolkit/api/status_mapping.py
+++ b/oneview_redfish_toolkit/api/status_mapping.py
@@ -49,7 +49,8 @@ COMPOSITION_STATE_MAPPING = {
     "NoProfileApplied": "Unused",
     "ApplyingProfile": "Composing",
     "ProfileApplied": "Composed",
-    "ProfileError": "Failed"
+    "ProfileError": "Failed",
+    "RemovingProfile": "Composed"
 }
 
 SERVER_HARDWARE_STATE_TO_REDFISH_STATE_MAPPING = {
@@ -97,5 +98,5 @@ def get_redfish_server_profile_state(resource):
 
 def get_redfish_composition_state(resource):
     composition_state = COMPOSITION_STATE_MAPPING.get(
-        resource["state"], None)
+        resource["state"])
     return composition_state

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -260,7 +260,7 @@ class TestResourceBlock(BaseFlaskTest):
             self.assertEqual("application/json", response.mimetype)
             self.assertEqualMockup(expected_rb, result)
 
-    def test_all_server_hardware_resouce_block_states_without_sp(self, g):
+    def test_all_server_hardware_resouce_block_states_without_sp(self):
         server_hardware = copy.deepcopy(self.server_hardware)
         server_hardware["serverProfileUri"] = None
         expected_rb = copy.deepcopy(self.expected_sh_resource_block)

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -223,11 +223,9 @@ class TestResourceBlock(BaseFlaskTest):
         self.assertEqual("application/json", response.mimetype)
         self.assertEqualMockup(self.expected_sh_resource_block, result)
 
-    def test_all_server_hardware_resouce_block_states(self):
-        self.maxDiff = None
+    def test_all_server_hardware_resouce_block_states_with_sp(self):
         server_hardware = copy.deepcopy(self.server_hardware)
         expected_rb = copy.deepcopy(self.expected_sh_resource_block)
-
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
         self.oneview_client.connection.get.return_value = \
@@ -239,8 +237,55 @@ class TestResourceBlock(BaseFlaskTest):
 
             server_hardware["state"] = oneview_state
             expected_rb["Status"]["State"] = redfish_state
+            expected_composition_state = status_mapping.\
+                COMPOSITION_STATE_MAPPING.get(oneview_state)
+
+            if not expected_composition_state:
+                expected_composition_state = \
+                    status_mapping.COMPOSITION_STATE_MAPPING["ProfileApplied"]
+
             expected_rb["CompositionStatus"]["CompositionState"] = \
-                status_mapping.COMPOSITION_STATE_MAPPING.get(oneview_state)
+                expected_composition_state
+
+            self.oneview_client.server_hardware.get.return_value = \
+                server_hardware
+
+            response = self.client.get(
+                "/redfish/v1/CompositionService/ResourceBlocks"
+                "/30303437-3034-4D32-3230-313133364752")
+
+            result = json.loads(response.data.decode("utf-8"))
+
+            self.assertEqual(status.HTTP_200_OK, response.status_code)
+            self.assertEqual("application/json", response.mimetype)
+            self.assertEqualMockup(expected_rb, result)
+
+    def test_all_server_hardware_resouce_block_states_without_sp(self, g):
+        server_hardware = copy.deepcopy(self.server_hardware)
+        server_hardware["serverProfileUri"] = None
+        expected_rb = copy.deepcopy(self.expected_sh_resource_block)
+        expected_rb["Links"].pop("ComputerSystems")
+        self.oneview_client.server_profile_templates.get_all.return_value = \
+            self.server_profile_templates
+        self.oneview_client.connection.get.return_value = \
+            self.log_encl_index_assoc
+        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+
+        for oneview_state, redfish_state in status_mapping.\
+                SERVER_HARDWARE_STATE_TO_REDFISH_STATE_MAPPING.items():
+
+            server_hardware["state"] = oneview_state
+            expected_rb["Status"]["State"] = redfish_state
+
+            expected_composition_state = status_mapping.\
+                COMPOSITION_STATE_MAPPING.get(oneview_state)
+
+            if not expected_composition_state:
+                expected_composition_state = status_mapping.\
+                    COMPOSITION_STATE_MAPPING["NoProfileApplied"]
+
+            expected_rb["CompositionStatus"]["CompositionState"] = \
+                expected_composition_state
 
             self.oneview_client.server_hardware.get.return_value = \
                 server_hardware


### PR DESCRIPTION
- Updating CompositionState mapping by including one more value
 - Adding server profile check when a server hardware state not found in CompositionState mapping. If ServerHardware has a server profile it will be composed and if not, it will be unused
 - Updating resource block unit test with this change and creating a new unit test when server hardware has not a server profile

Closes #380 