### PR TITLE
Change Oneview Redfish Toolkit to use CherryPy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ ChangeLog
 # Created logging file
 *.log
 
+# The app can create a pid file
+*.pid
+
 # Files created when running the API
 oneview_redfish_toolkit/__pycache__/
 oneview_redfish_toolkit/tests/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,6 @@ ChangeLog
 # Created logging file
 *.log
 
-# The app can create a pid file
-*.pid
-
 # Files created when running the API
 oneview_redfish_toolkit/__pycache__/
 oneview_redfish_toolkit/tests/__pycache__/

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -406,16 +406,14 @@ if __name__ == '__main__':
                         help='A required path to logging config file')
     parser.add_argument('--dev', type=bool,
                         default=False, choices=[True, False],
-                        help='A optional value True or False to say if the '
-                             'application should run in a development mode. '
-                             'This will run a CherryPy server.')
+                        help='Optional value True or False to say if the '
+                             'application should run in development mode.')
     parser.add_argument('--debug', type=bool,
                         default=False, choices=[True, False],
-                        help='A optional value True or False to say if the '
-                             'application should run in a debug mode, this '
+                        help='Optional value True or False to say if the '
+                             'application should run in debug mode, this '
                              'option only is valid when the development mode '
-                             'is set to True too, otherwise it is ignored. '
-                             'This will run a Flask server')
+                             'is set to True too, otherwise it is ignored.')
     args = parser.parse_args()
 
     main(args.config, args.log_config,

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -404,16 +404,16 @@ if __name__ == '__main__':
                         help='A required path to config file')
     parser.add_argument('--log-config', type=str,
                         help='A required path to logging config file')
-    parser.add_argument('--dev', type=bool,
-                        default=False, choices=[True, False],
-                        help='Optional value True or False to say if the '
-                             'application should run in development mode.')
-    parser.add_argument('--debug', type=bool,
-                        default=False, choices=[True, False],
-                        help='Optional value True or False to say if the '
-                             'application should run in debug mode, this '
-                             'option only is valid when the development mode '
-                             'is set to True too, otherwise it is ignored.')
+    parser.add_argument('--dev', type=bool, nargs='?',
+                        default=False, const=True,
+                        help='Optional value to tell the application to run '
+                             'in development mode.')
+    parser.add_argument('--debug', type=bool, nargs='?',
+                        default=False, const=True,
+                        help='Optional value to tell the application to run '
+                             'in debug mode, this option only is valid when '
+                             'the development mode is set too, otherwise '
+                             'it is ignored.')
     args = parser.parse_args()
 
     main(args.config, args.log_config,

--- a/oneview_redfish_toolkit/conf/redfish.conf
+++ b/oneview_redfish_toolkit/conf/redfish.conf
@@ -4,7 +4,6 @@ xml_prettify = True
 redfish_host = 0.0.0.0
 redfish_port = 5000
 authentication_mode = session
-debug = false
 
 [oneview_config]
 ip =

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,13 @@
 # process, which may cause wedges in the gate later.
 
 appdirs
+cherrypy
 configparser
 flask
 flask-api
 hpOneView
 jsonschema
+paste
 pbr>=2.0 # Apache-2.0
 pika
 pyOpenSSL

--- a/run.sh
+++ b/run.sh
@@ -16,4 +16,4 @@
 # under the License.
 PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}.
 export PYTHONPATH=$PYTHONPATH
-python3 oneview_redfish_toolkit/app.py --config oneview_redfish_toolkit/conf/redfish.conf --log-config oneview_redfish_toolkit/conf/logging.conf
+python3 oneview_redfish_toolkit/app.py --config oneview_redfish_toolkit/conf/redfish.conf --log-config oneview_redfish_toolkit/conf/logging.conf --dev true

--- a/run.sh
+++ b/run.sh
@@ -16,4 +16,4 @@
 # under the License.
 PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}.
 export PYTHONPATH=$PYTHONPATH
-python3 oneview_redfish_toolkit/app.py --config oneview_redfish_toolkit/conf/redfish.conf --log-config oneview_redfish_toolkit/conf/logging.conf --dev true
+python3 oneview_redfish_toolkit/app.py --config oneview_redfish_toolkit/conf/redfish.conf --log-config oneview_redfish_toolkit/conf/logging.conf --dev


### PR DESCRIPTION
- Changes the app.py code to use CherryPy standard;
- Adds TransLogger to handler logs between cherrypy and flask app
- Uses Daemonizer plugin of the cherrypy to run the app as a daemon process
- Changes the requirements.txt adding the cherrypy to be installed

Closes #348 