### PR TITLE
Use a label to save template_UUID instead of Description attribute in the server profile

### DIFF
--- a/oneview_redfish_toolkit/api/computer_system.py
+++ b/oneview_redfish_toolkit/api/computer_system.py
@@ -45,7 +45,7 @@ class ComputerSystem(RedfishJsonValidator):
     BASE_URI = '/redfish/v1/Systems'
 
     def __init__(self, server_hardware, server_hardware_types,
-                 server_profile, drives, server_profile_labels):
+                 server_profile, drives, server_profile_template_uuid):
         """ComputerSystem constructor
 
             Populates self.redfish with the contents of ServerHardware and
@@ -56,7 +56,7 @@ class ComputerSystem(RedfishJsonValidator):
                 server_hardware_types: ServerHardwareTypes dict from OneView
                 server_profile: ServerProfile dict from OneView.
                 drives: Drives list from OneView
-                server_profile_labels: Server Profile labels from Oneview
+                server_profile_template_uuid: ServerProfileTemplate uuid
         """
         super().__init__(self.SCHEMA_NAME)
 
@@ -116,7 +116,7 @@ class ComputerSystem(RedfishJsonValidator):
         self.redfish["Links"]["ResourceBlocks"] = list()
         self._fill_resource_block_members(drives,
                                           server_hardware,
-                                          server_profile_labels)
+                                          server_profile_template_uuid)
         self.redfish["Actions"] = collections.OrderedDict()
         self.redfish["Actions"]["#ComputerSystem.Reset"] = \
             collections.OrderedDict()
@@ -239,11 +239,11 @@ class ComputerSystem(RedfishJsonValidator):
     def _fill_resource_block_members(self,
                                      drives,
                                      server_hardware,
-                                     server_profile_labels):
+                                     server_profile_template_uuid):
         resource_block_uuids = \
             self._get_resource_block_uuids(drives,
                                            server_hardware,
-                                           server_profile_labels)
+                                           server_profile_template_uuid)
 
         base_uri = ResourceBlockCollection.BASE_URI + "/{}"
         blocks = self.redfish["Links"]["ResourceBlocks"]
@@ -253,13 +253,13 @@ class ComputerSystem(RedfishJsonValidator):
     def _get_resource_block_uuids(self,
                                   drives,
                                   server_hardware,
-                                  server_profile_labels):
+                                  server_profile_template_uuid):
         resource_block_uuids = list()
         resource_block_uuids.append(server_hardware["uuid"])
 
         # fill with network resource block
-        spt_id = server_profile_labels["labels"][0]["name"].replace(" ", "-")
-        resource_block_uuids.append(spt_id)
+        if server_profile_template_uuid:
+            resource_block_uuids.append(server_profile_template_uuid)
 
         for drive in drives:
             storage_resource_uuid = drive["uri"].split("/")[-1]

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -73,12 +73,15 @@ def get_computer_system(uuid):
                 .get(resource['serverHardwareTypeUri'])
 
             drives = _get_drives_from_sp(resource)
+            sp_labels = \
+                g.oneview_client.labels.get_by_resource(resource["uri"])
 
             # Build Computer System object and validates it
             computer_system_resource = ComputerSystem(server_hardware,
                                                       server_hardware_type,
                                                       resource,
-                                                      drives)
+                                                      drives,
+                                                      sp_labels)
         else:
             raise OneViewRedfishError(
                 'Computer System UUID {} not found'.format(uuid))
@@ -230,6 +233,9 @@ def create_composed_system():
         if resource_uri:
             result_uuid = resource_uri.split("/")[-1]
             result_location_uri = ComputerSystem.BASE_URI + "/" + result_uuid
+            server_profile_label = dict(
+                resourceUri=resource_uri, labels=[spt_id.replace("-", " ")])
+            g.oneview_client.labels.create(server_profile_label)
         elif task.get("taskErrors"):
             err_msg = reduce(
                 lambda result, msg: result + msg["message"] + "\n",

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -34,6 +34,7 @@ from jsonschema import ValidationError
 
 from oneview_redfish_toolkit.api.capabilities_object import CapabilitiesObject
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
+from oneview_redfish_toolkit.api.errors import NOT_FOUND_ONEVIEW_ERRORS
 from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
@@ -345,7 +346,7 @@ def _get_server_profile_template_from_sp(sp_uri):
                 server_profile_template_uuid = spt_uuid
                 break
         except HPOneViewException as e:
-            if e.oneview_response["errorCode"] == 'RESOURCE_NOT_FOUND':
+            if e.oneview_response["errorCode"] in NOT_FOUND_ONEVIEW_ERRORS:
                 pass
             else:
                 raise

--- a/oneview_redfish_toolkit/handler_multiple_oneview.py
+++ b/oneview_redfish_toolkit/handler_multiple_oneview.py
@@ -73,6 +73,10 @@ RESOURCE_STRATEGY = {
     "tasks": {
         "get": st.first_parameter_resource
         },
+    "labels": {
+        "create": st.create_labels,
+        "get_by_resource": st.first_parameter_resource
+        },
 }
 
 

--- a/oneview_redfish_toolkit/mockups/oneview/LabelForServerProfile.json
+++ b/oneview_redfish_toolkit/mockups/oneview/LabelForServerProfile.json
@@ -6,7 +6,7 @@
    "uri":"/rest/labels/resources/rest/server-profiles/b425802b-a6a5-4941-8885-aab68dfa2ee2",
    "labels":[
       {
-         "uri":"/rest/labels/14",
+         "uri":"/rest/labels/1",
          "name":"61c3a463 1355 4c68 a4e3 4f08c322af1b"
       }
    ],

--- a/oneview_redfish_toolkit/mockups/oneview/ServerProfileWithLabels.json
+++ b/oneview_redfish_toolkit/mockups/oneview/ServerProfileWithLabels.json
@@ -1,0 +1,15 @@
+{
+   "resourceUri":"/rest/server-profiles/b425802b-a6a5-4941-8885-aab68dfa2ee2",
+   "type":"ResourceLabels",
+   "modified":"2018-08-30T16:49:29.397Z",
+   "created":"2018-08-30T16:49:29.397Z",
+   "uri":"/rest/labels/resources/rest/server-profiles/b425802b-a6a5-4941-8885-aab68dfa2ee2",
+   "labels":[
+      {
+         "uri":"/rest/labels/14",
+         "name":"61c3a463 1355 4c68 a4e3 4f08c322af1b"
+      }
+   ],
+   "eTag":"1",
+   "category":"server-profiles"
+}

--- a/oneview_redfish_toolkit/strategy_multiple_oneview.py
+++ b/oneview_redfish_toolkit/strategy_multiple_oneview.py
@@ -96,6 +96,14 @@ def update_power_state_server_hardware(resource, function, *args, **kwargs):
                        function, *args, **kwargs)
 
 
+def create_labels(resource, function, *args, **kwargs):
+    resource_id = args[0]["resourceUri"]
+
+    return \
+        _run_action(resource_id, 'server_profiles', 'get', resource,
+                    function, *args, **kwargs)
+
+
 def _run_action(resource_id, resource_get, function_get, resource,
                 function, *args, **kwargs):
 

--- a/oneview_redfish_toolkit/tests/api/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/api/test_computer_system.py
@@ -50,6 +50,13 @@ class TestComputerSystem(BaseTest):
         ) as f:
             self.drives = json.load(f)
 
+        # Loading ServerProfileWithLabels mockup result
+        with open(
+                'oneview_redfish_toolkit/mockups/oneview'
+                '/ServerProfileWithLabels.json'
+        ) as f:
+            self.server_profile_labels = json.load(f)
+
         # Loading ComputerSystem mockup result
         with open(
             'oneview_redfish_toolkit/mockups/redfish/ComputerSystem.json'
@@ -62,7 +69,8 @@ class TestComputerSystem(BaseTest):
             self.server_hardware,
             self.server_hardware_types,
             self.server_profile,
-            [self.drives[4]]
+            [self.drives[4]],
+            self.server_profile_labels
         )
 
         result = json.loads(computer_system.serialize())

--- a/oneview_redfish_toolkit/tests/api/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/api/test_computer_system.py
@@ -50,12 +50,12 @@ class TestComputerSystem(BaseTest):
         ) as f:
             self.drives = json.load(f)
 
-        # Loading ServerProfileWithLabels mockup result
+        # Loading LabelForServerProfile mockup result
         with open(
                 'oneview_redfish_toolkit/mockups/oneview'
-                '/ServerProfileWithLabels.json'
+                '/LabelForServerProfile.json'
         ) as f:
-            self.server_profile_labels = json.load(f)
+            self.label_for_server_profile = json.load(f)
 
         # Loading ComputerSystem mockup result
         with open(
@@ -65,12 +65,13 @@ class TestComputerSystem(BaseTest):
 
     def test_serialize(self):
         # Tests the serialize function result against known result
+        spt_uuid = "61c3a463-1355-4c68-a4e3-4f08c322af1b"
         computer_system = ComputerSystem(
             self.server_hardware,
             self.server_hardware_types,
             self.server_profile,
             [self.drives[4]],
-            self.server_profile_labels
+            spt_uuid
         )
 
         result = json.loads(computer_system.serialize())

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
@@ -84,6 +84,13 @@ class TestComputerSystem(BaseFlaskTest):
         ) as f:
             self.drives = json.load(f)
 
+        # Loading ServerProfileWithLabels mockup result
+        with open(
+                'oneview_redfish_toolkit/mockups/oneview'
+                '/ServerProfileWithLabels.json'
+        ) as f:
+            self.server_profile_labels = json.load(f)
+
     def test_get_computer_system_not_found(self):
         """Tests ComputerSystem with ServerProfileTemplates not found"""
 
@@ -240,6 +247,8 @@ class TestComputerSystem(BaseFlaskTest):
             self.server_hardware_types
         self.oneview_client.sas_logical_jbods.get_drives.return_value = \
             [self.drives[4]]
+        self.oneview_client.labels.get_by_resource.return_value = \
+            self.server_profile_labels
 
         # Get ComputerSystem
         response = self.client.get(
@@ -270,6 +279,10 @@ class TestComputerSystem(BaseFlaskTest):
         )
         self.oneview_client.server_profile_templates.get \
             .assert_not_called()
+
+        self.oneview_client.labels.get_by_resource.assert_called_with(
+            "/rest/server-profiles/b425802b-a6a5-4941-8885-aab68dfa2ee2"
+        )
 
     def test_get_computer_system_spt(self):
         """Tests ComputerSystem with a known Server Profile Templates"""
@@ -578,6 +591,8 @@ class TestComputerSystem(BaseFlaskTest):
                 self.server_hardware_types
             self.oneview_client.sas_logical_jbods.get_drives.return_value = \
                 [self.drives[4]]
+            self.oneview_client.labels.get_by_resource.return_value = \
+                self.server_profile_labels
 
             response = self.client.get(
                 "/redfish/v1/Systems/b425802b-a6a5-4941-8885-aab68dfa2ee2"
@@ -608,6 +623,8 @@ class TestComputerSystem(BaseFlaskTest):
                 self.server_hardware_types
             self.oneview_client.sas_logical_jbods.get_drives.return_value = \
                 [self.drives[4]]
+            self.oneview_client.labels.get_by_resource.return_value = \
+                self.server_profile_labels
 
             response = self.client.get(
                 "/redfish/v1/Systems/b425802b-a6a5-4941-8885-aab68dfa2ee2"


### PR DESCRIPTION
 - Creating a new handle to post a new label associated with a server profile using server profile template description as label
 - Replacing server profile template description from server profile to use labels associated with a server profile
 - Fixing unit tests to use labels instead server profile description

Closes #370 