### PR TITLE
Login session workflow

### DIFF
--- a/oneview_redfish_toolkit/api/errors.py
+++ b/oneview_redfish_toolkit/api/errors.py
@@ -19,7 +19,8 @@ NOT_FOUND_ONEVIEW_ERRORS = ['RESOURCE_NOT_FOUND', 'ProfileNotFoundException',
                             'DFRM_SAS_LOGICAL_JBOD_NOT_FOUND']
 
 AUTH_ONEVIEW_ERRORS = ['AUTHN_AUTH_FAIL',
-                       'AUTHN_AUTH_FAIL_LOGINDOMAINNOTFOUND']
+                       'AUTHN_AUTH_FAIL_LOGINDOMAINNOTFOUND',
+                       'AUTHORIZATION']
 
 
 class OneViewRedfishError(Exception):

--- a/oneview_redfish_toolkit/api/schemas.py
+++ b/oneview_redfish_toolkit/api/schemas.py
@@ -56,6 +56,7 @@ SCHEMAS = {
     "ZoneCollection": "ZoneCollection.json",
     "Zone": "Zone.v1_2_0.json",
     "Session": "Session.v1_1_0.json",
+    "SessionCollection": "SessionCollection.json",
     "EventDestinationCollection": "EventDestinationCollection.json",
 }
 

--- a/oneview_redfish_toolkit/api/session.py
+++ b/oneview_redfish_toolkit/api/session.py
@@ -41,7 +41,7 @@ class Session(RedfishJsonValidator):
         self.redfish["@odata.context"] = \
             "/redfish/v1/$metadata#Session.Session"
         self.redfish["@odata.id"] = \
-            SessionCollection.BASE_URI + str(session_id)
+            SessionCollection.BASE_URI + "/" + str(session_id)
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = str(session_id)
         self.redfish["Name"] = "User Session"

--- a/oneview_redfish_toolkit/api/session_collection.py
+++ b/oneview_redfish_toolkit/api/session_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
+# Copyright (2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -16,34 +16,37 @@
 
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
-from oneview_redfish_toolkit.api.session_collection import SessionCollection
 
 
-class Session(RedfishJsonValidator):
-    """Super class of Session Service
+class SessionCollection(RedfishJsonValidator):
+    """Session Collection class
 
-        Populates self.redfish with Session response.
+        Populates self.redfish with a list of active sessions.
     """
 
-    SCHEMA_NAME = 'Session'
+    BASE_URI = "/redfish/v1/SessionService/Sessions/"
+    SCHEMA_NAME = 'SessionCollection'
 
-    def __init__(self, session_id):
+    def __init__(self, ids):
         """Session constructor
 
             Populates self.redfish with Session response.
 
             Args:
-                session_id: The session ID of the user logged in
+                ids: List with id of sessions
         """
 
         super().__init__(self.SCHEMA_NAME)
 
         self.redfish["@odata.context"] = \
-            "/redfish/v1/$metadata#Session.Session"
-        self.redfish["@odata.id"] = \
-            SessionCollection.BASE_URI + str(session_id)
+            "/redfish/v1/$metadata#SessionCollection.SessionCollection"
+        self.redfish["@odata.id"] = self.BASE_URI
         self.redfish["@odata.type"] = self.get_odata_type()
-        self.redfish["Id"] = str(session_id)
-        self.redfish["Name"] = "User Session"
+        self.redfish["Name"] = "Active sessions"
+        self.redfish["Members"] = [self._build_member(s_id) for s_id in ids]
+        self.redfish["Members@odata.count"] = len(self.redfish["Members"])
 
         self._validate()
+
+    def _build_member(self, session_id):
+        return {"@odata.id": self.BASE_URI + str(session_id)}

--- a/oneview_redfish_toolkit/api/session_collection.py
+++ b/oneview_redfish_toolkit/api/session_collection.py
@@ -24,7 +24,7 @@ class SessionCollection(RedfishJsonValidator):
         Populates self.redfish with a list of active sessions.
     """
 
-    BASE_URI = "/redfish/v1/SessionService/Sessions/"
+    BASE_URI = "/redfish/v1/SessionService/Sessions"
     SCHEMA_NAME = 'SessionCollection'
 
     def __init__(self, ids):
@@ -49,4 +49,4 @@ class SessionCollection(RedfishJsonValidator):
         self._validate()
 
     def _build_member(self, session_id):
-        return {"@odata.id": self.BASE_URI + str(session_id)}
+        return {"@odata.id": self.BASE_URI + "/" + str(session_id)}

--- a/oneview_redfish_toolkit/blueprints/session.py
+++ b/oneview_redfish_toolkit/blueprints/session.py
@@ -41,7 +41,8 @@ def get_collection():
     return ResponseBuilder.success(result)
 
 
-@session.route(SessionCollection.BASE_URI + "<session_id>", methods=["GET"])
+@session.route(SessionCollection.BASE_URI + "/" + "<session_id>",
+               methods=["GET"])
 def get_session(session_id):
     if session_id not in client_session.get_session_ids():
         abort(status.HTTP_404_NOT_FOUND)

--- a/oneview_redfish_toolkit/mockups/redfish/Session.json
+++ b/oneview_redfish_toolkit/mockups/redfish/Session.json
@@ -1,9 +1,7 @@
 {
     "@odata.context": "/redfish/v1/$metadata#Session.Session",
-    "@odata.id": "/redfish/v1/SessionService/Sessions/1",
+    "@odata.id": "/redfish/v1/SessionService/Sessions/e2807c0b-87d6-4304-a773-6ec33521fb1c",
     "@odata.type": "#Session.v1_1_0.Session",
-    "Id": "1",
-    "Name": "User Session",
-    "Description": "User Session",
-    "UserName": "administrator"
+    "Id": "e2807c0b-87d6-4304-a773-6ec33521fb1c",
+    "Name": "User Session"
 }

--- a/oneview_redfish_toolkit/mockups/redfish/SessionCollection.json
+++ b/oneview_redfish_toolkit/mockups/redfish/SessionCollection.json
@@ -1,0 +1,18 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#SessionCollection.SessionCollection",
+  "@odata.id": "/redfish/v1/SessionService/Sessions/",
+  "@odata.type": "#SessionCollection.SessionCollection",
+  "Name": "Active sessions",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/SessionService/Sessions/e2807c0b-87d6-4304-a773-6ec33521fb1c"
+    },
+    {
+      "@odata.id": "/redfish/v1/SessionService/Sessions/709cf49b-f367-417e-af70-ede782e0fa3c"
+    },
+    {
+      "@odata.id": "/redfish/v1/SessionService/Sessions/cd825af3-05c5-44a1-85f7-84e6e2e9fcb3"
+    }
+  ],
+  "Members@odata.count": 3
+}

--- a/oneview_redfish_toolkit/mockups/redfish/SessionCollection.json
+++ b/oneview_redfish_toolkit/mockups/redfish/SessionCollection.json
@@ -1,6 +1,6 @@
 {
   "@odata.context": "/redfish/v1/$metadata#SessionCollection.SessionCollection",
-  "@odata.id": "/redfish/v1/SessionService/Sessions/",
+  "@odata.id": "/redfish/v1/SessionService/Sessions",
   "@odata.type": "#SessionCollection.SessionCollection",
   "Name": "Active sessions",
   "Members": [

--- a/oneview_redfish_toolkit/mockups/redfish/SessionCollectionEmpty.json
+++ b/oneview_redfish_toolkit/mockups/redfish/SessionCollectionEmpty.json
@@ -1,0 +1,8 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#SessionCollection.SessionCollection",
+  "@odata.id": "/redfish/v1/SessionService/Sessions/",
+  "@odata.type": "#SessionCollection.SessionCollection",
+  "Name": "Active sessions",
+  "Members": [],
+  "Members@odata.count": 0
+}

--- a/oneview_redfish_toolkit/mockups/redfish/SessionCollectionEmpty.json
+++ b/oneview_redfish_toolkit/mockups/redfish/SessionCollectionEmpty.json
@@ -1,6 +1,6 @@
 {
   "@odata.context": "/redfish/v1/$metadata#SessionCollection.SessionCollection",
-  "@odata.id": "/redfish/v1/SessionService/Sessions/",
+  "@odata.id": "/redfish/v1/SessionService/Sessions",
   "@odata.type": "#SessionCollection.SessionCollection",
   "Name": "Active sessions",
   "Members": [],

--- a/oneview_redfish_toolkit/mockups/redfish/SessionForLoginWithDomain.json
+++ b/oneview_redfish_toolkit/mockups/redfish/SessionForLoginWithDomain.json
@@ -1,9 +1,7 @@
 {
     "@odata.context": "/redfish/v1/$metadata#Session.Session",
-    "@odata.id": "/redfish/v1/SessionService/Sessions/1",
+    "@odata.id": "/redfish/v1/SessionService/Sessions/e2807c0b-87d6-4304-a773-6ec33521fb1c",
     "@odata.type": "#Session.v1_1_0.Session",
-    "Id": "1",
-    "Name": "User Session",
-    "Description": "User Session",
-    "UserName": "LOCAL\\administrator"
+    "Id": "e2807c0b-87d6-4304-a773-6ec33521fb1c",
+    "Name": "User Session"
 }

--- a/oneview_redfish_toolkit/tests/api/test_session.py
+++ b/oneview_redfish_toolkit/tests/api/test_session.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -24,19 +24,10 @@ from oneview_redfish_toolkit.tests.base_test import BaseTest
 class TestSession(BaseTest):
     """Tests for Session class"""
 
-    def test_class_instantiation(self):
-        """Tests class instantiation and validation"""
-
-        try:
-            session = Session("administrator")
-        except Exception as e:
-            self.fail("Failed to instantiate Session. Error: ".format(e))
-        self.assertIsInstance(session, Session)
-
     def test_serialize(self):
         """Tests the serialize function result against known result"""
 
-        session = Session("administrator")
+        session = Session("e2807c0b-87d6-4304-a773-6ec33521fb1c")
         result = json.loads(session.serialize())
 
         with open(

--- a/oneview_redfish_toolkit/tests/blueprints/test_session.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_session.py
@@ -28,12 +28,15 @@ from oneview_redfish_toolkit.blueprints.session \
     import session as session_blueprint
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
+from oneview_redfish_toolkit.blueprints.zone_collection import zone_collection
 from oneview_redfish_toolkit import client_session
 from oneview_redfish_toolkit import config
 from oneview_redfish_toolkit import connection
 from oneview_redfish_toolkit.tests.base_flask_test import BaseFlaskTest
 
 
+@mock.patch.object(client_session, 'uuid')
+@mock.patch.object(connection, 'OneViewClient')
 class TestSession(BaseFlaskTest):
     """Tests for Session blueprint"""
 
@@ -42,16 +45,113 @@ class TestSession(BaseFlaskTest):
         super(TestSession, self).setUpClass()
 
         self.app.register_blueprint(session_blueprint)
+        self.app.register_blueprint(zone_collection)
 
         @self.app.errorhandler(status.HTTP_401_UNAUTHORIZED)
         def unauthorized_error(error):
             """Creates a Unauthorized Error response"""
             return ResponseBuilder.error_401(error)
 
-    @mock.patch.object(connection, 'OneViewClient')
+        self.session_id = "e2807c0b-87d6-4304-a773-6ec33521fb1c"
+        self.token_id = "abc"
+
+        self.session_ids = [
+            'e2807c0b-87d6-4304-a773-6ec33521fb1c',
+            '709cf49b-f367-417e-af70-ede782e0fa3c',
+            'cd825af3-05c5-44a1-85f7-84e6e2e9fcb3'
+        ]
+
+    def test_get_session_collection(self, _, uuid_mock):
+        """Tests get Session Collection"""
+
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish/'
+                'SessionCollection.json'
+        ) as f:
+            expected_session_collection = json.load(f)
+
+        uuid_mock.uuid4.side_effect = self.session_ids
+
+        client_session.init_map_clients()
+        client_session._set_new_client_by_token('abc', '10.0.0.1')
+        client_session._set_new_client_by_token('def', '10.0.0.2')
+        client_session._set_new_client_by_token('ghi', '10.0.0.3')
+
+        response = self.client.get(
+            "/redfish/v1/SessionService/Sessions",
+            content_type='application/json')
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqualMockup(expected_session_collection, result)
+
+    def test_get_session_collection_when_is_empty(self, _, __):
+        """Tests get Session Collection when active session list is empty"""
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish/'
+                'SessionCollectionEmpty.json'
+        ) as f:
+            expected_session_collection = json.load(f)
+
+        client_session.init_map_clients()
+
+        response = self.client.get(
+            "/redfish/v1/SessionService/Sessions",
+            content_type='application/json')
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqualMockup(expected_session_collection, result)
+
+    def test_get_session(self, _, uuid_mock):
+        """Tests get a specific Session"""
+
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish/Session.json'
+        ) as f:
+            expected_session = json.load(f)
+
+        uuid_mock.uuid4.side_effect = self.session_ids
+
+        client_session.init_map_clients()
+        client_session._set_new_client_by_token('abc', '10.0.0.1')
+        client_session._set_new_client_by_token('def', '10.0.0.2')
+
+        response = self.client.get(
+            "/redfish/v1/SessionService/Sessions/" + expected_session["Id"],
+            content_type='application/json')
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqualMockup(expected_session, result)
+
+    def test_get_session_when_is_not_cached(self, _, uuid_mock):
+        """Tests get a specific Session when session id is not present"""
+
+        uuid_mock.uuid4.return_value = '709cf49b-f367-417e-af70-ede782e0fa3c'
+
+        client_session.init_map_clients()
+        client_session._set_new_client_by_token('abc', '10.0.0.1')
+
+        response = self.client.get(
+            "/redfish/v1/SessionService/Sessions/"
+            "e2807c0b-87d6-4304-a773-6ec33521fb1c",
+            content_type='application/json')
+
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+
     @mock.patch.object(config, 'get_authentication_mode')
-    def test_post_session(self, get_authentication_mode,
-                          oneview_client_mockup):
+    def test_post_session(self,
+                          get_authentication_mode,
+                          oneview_client_mockup,
+                          uuid_mock):
         """Tests post Session"""
 
         # Loading Session mockup result
@@ -64,8 +164,9 @@ class TestSession(BaseFlaskTest):
         get_authentication_mode.return_value = 'session'
 
         # Create mock response
+        uuid_mock.uuid4.return_value = self.session_id
         oneview_client = oneview_client_mockup()
-        oneview_client.connection.get_session_id.return_value = "sessionId"
+        oneview_client.connection.get_session_id.return_value = self.token_id
 
         # POST Session
         response = self.client.post(
@@ -82,9 +183,9 @@ class TestSession(BaseFlaskTest):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqualMockup(expected_session_mockup, result)
-        self.assertIn("/redfish/v1/SessionService/Sessions/1",
+        self.assertIn("/redfish/v1/SessionService/Sessions/" + self.session_id,
                       response.headers["Location"])
-        self.assertEqual("sessionId", response.headers["X-Auth-Token"])
+        self.assertEqual(self.token_id, response.headers["X-Auth-Token"])
         oneview_client_mockup.assert_called_with(
             {
                 'ip': config.get_oneview_multiple_ips()[0],
@@ -96,10 +197,69 @@ class TestSession(BaseFlaskTest):
             }
         )
 
-    @mock.patch.object(connection, 'OneViewClient')
+        # gets the session by id
+        response_of_get = self.client.get(response.headers["Location"],
+                                          content_type='application/json')
+
+        result_of_get = json.loads(response_of_get.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response_of_get.status_code)
+        self.assertEqual(self.session_id, result_of_get["Id"])
+
+    def test_post_many_sessions(self, oneview_client_mockup, uuid_mock):
+        """Tests post many Sessions and gets them"""
+
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish/'
+                'SessionCollection.json'
+        ) as f:
+            expected_session_collection = json.load(f)
+
+        client_session.init_map_clients()
+
+        session_ids = self.session_ids
+        uuid_mock.uuid4.side_effect = session_ids
+
+        oneview_client = oneview_client_mockup()
+        oneview_client.connection.get_session_id.side_effect = [
+            'abc',
+            'def',
+            'ghi'
+        ]
+
+        self.client.post(
+            "/redfish/v1/SessionService/Sessions",
+            data=json.dumps(dict(
+                UserName="user_1",
+                Password="password")),
+            content_type='application/json')
+
+        self.client.post(
+            "/redfish/v1/SessionService/Sessions",
+            data=json.dumps(dict(
+                UserName="user_2",
+                Password="password")),
+            content_type='application/json')
+
+        self.client.post(
+            "/redfish/v1/SessionService/Sessions",
+            data=json.dumps(dict(
+                UserName="user_3",
+                Password="password")),
+            content_type='application/json')
+
+        response = self.client.get('/redfish/v1/SessionService/Sessions',
+                                   content_type='application/json')
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(expected_session_collection, result)
+
     @mock.patch.object(config, 'get_authentication_mode')
-    def test_post_session_with_login_domain_data(self, get_authentication_mode,
-                                                 oneview_client_mockup):
+    def test_post_session_with_login_domain_data(self,
+                                                 get_authentication_mode,
+                                                 oneview_client_mockup,
+                                                 uuid_mock):
         """Tests post Session when UserName has login domain information"""
 
         with open(
@@ -112,8 +272,9 @@ class TestSession(BaseFlaskTest):
         get_authentication_mode.return_value = 'session'
 
         # Create mock response
+        uuid_mock.uuid4.return_value = self.session_id
         oneview_client = oneview_client_mockup()
-        oneview_client.connection.get_session_id.return_value = "sessionId"
+        oneview_client.connection.get_session_id.return_value = self.token_id
 
         # POST Session
         response = self.client.post(
@@ -130,9 +291,9 @@ class TestSession(BaseFlaskTest):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
         self.assertEqualMockup(expected_session_mockup, result)
-        self.assertIn("/redfish/v1/SessionService/Sessions/1",
+        self.assertIn("/redfish/v1/SessionService/Sessions/" + self.session_id,
                       response.headers["Location"])
-        self.assertEqual("sessionId", response.headers["X-Auth-Token"])
+        self.assertEqual(self.token_id, response.headers["X-Auth-Token"])
         oneview_client_mockup.assert_called_with(
             {
                 'ip': config.get_oneview_multiple_ips()[0],
@@ -145,13 +306,12 @@ class TestSession(BaseFlaskTest):
             }
         )
 
-    @mock.patch.object(connection, 'OneViewClient')
-    def test_post_session_invalid_key(self, oneview_client_mockup):
+    def test_post_session_invalid_key(self, oneview_client_mockup, _):
         """Tests post session with an invalid JSON key"""
 
         # Create mock response
         oneview_client = oneview_client_mockup()
-        oneview_client.connection.get_session_id.return_value = "sessionId"
+        oneview_client.connection.get_session_id.return_value = self.token_id
 
         # POST Session
         response = self.client.post(
@@ -177,8 +337,7 @@ class TestSession(BaseFlaskTest):
         self.assertEqual("application/json", response.mimetype)
         self.assertEqual(result, invalid_json_key)
 
-    @mock.patch.object(connection, 'OneViewClient')
-    def test_post_session_oneview_exception(self, oneview_client_mockup):
+    def test_post_session_oneview_exception(self, oneview_client_mockup, _):
         """Tests post session with HPOneViewException"""
 
         oneview_client = oneview_client_mockup()
@@ -204,8 +363,7 @@ class TestSession(BaseFlaskTest):
         )
         self.assertEqual("application/json", response.mimetype)
 
-    @mock.patch.object(connection, 'OneViewClient')
-    def test_post_session_unexpected_error(self, oneview_client_mockup):
+    def test_post_session_unexpected_error(self, oneview_client_mockup, _):
         """Tests post session with an unexpected error"""
 
         oneview_client = oneview_client_mockup()
@@ -225,3 +383,56 @@ class TestSession(BaseFlaskTest):
             response.status_code
         )
         self.assertEqual("application/json", response.mimetype)
+
+    @mock.patch.object(config, 'get_authentication_mode')
+    def test_remove_token_when_authorization_token_fail(self,
+                                                        get_auth_mode,
+                                                        _,
+                                                        uuid_mock):
+        """Tests removing a session when Oneview raises authorization error"""
+
+        err = HPOneViewException({
+            'errorCode': 'AUTHORIZATION',
+            'message': 'Invalid user information',
+        })
+
+        get_auth_mode.return_value = 'session'
+        uuid_mock.uuid4.side_effect = self.session_ids
+
+        self.oneview_client.server_profile_templates.get_all.side_effect = err
+
+        client_session.init_map_clients()
+        client_session._set_new_client_by_token('abc', '10.0.0.1')
+        client_session._set_new_client_by_token('def', '10.0.0.2')
+        client_session._set_new_client_by_token('ghi', '10.0.0.3')
+
+        # Raises the error
+        response = self.client.get('/redfish/v1/CompositionService/'
+                                   'ResourceZones',
+                                   headers={'X-Auth-Token': 'abc'},
+                                   content_type='application/json')
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
+        self.assertEqual('application/json', response.mimetype)
+        self.assertIn('Invalid user information', str(result))
+
+        # when gets the Active Session should have only 2 sessions
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish/'
+                'SessionCollection.json'
+        ) as f:
+            expected_session_collection = json.load(f)
+            del expected_session_collection["Members"][0]
+            expected_session_collection["Members@odata.count"] = 2
+
+        resp_active_sess = self.client.get(
+            "/redfish/v1/SessionService/Sessions",
+            content_type='application/json')
+
+        result_active_sess = json.loads(resp_active_sess.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, resp_active_sess.status_code)
+        self.assertEqual("application/json", resp_active_sess.mimetype)
+        self.assertEqualMockup(expected_session_collection, result_active_sess)


### PR DESCRIPTION
- Adds SessionCollection endpoint
- Adds endpoint of Session by id
- Removes session when authorization error is raised by Oneview
- Supports more than one session in cache

Closes #407 
Closes #408 