### PR TITLE
Feature/garbage collector for expired sessions

### DIFF
--- a/oneview_redfish_toolkit/api/errors.py
+++ b/oneview_redfish_toolkit/api/errors.py
@@ -20,7 +20,8 @@ NOT_FOUND_ONEVIEW_ERRORS = ['RESOURCE_NOT_FOUND', 'ProfileNotFoundException',
 
 AUTH_ONEVIEW_ERRORS = ['AUTHN_AUTH_FAIL',
                        'AUTHN_AUTH_FAIL_LOGINDOMAINNOTFOUND',
-                       'AUTHORIZATION']
+                       'AUTHORIZATION',
+                       'Session.INVALID']
 
 
 class OneViewRedfishError(Exception):

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -167,6 +167,7 @@ def main(config_file_path, logging_config_file_path,
 
     # Init cached data
     client_session.init_map_clients()
+    client_session.init_gc_for_expired_sessions()
     multiple_oneview.init_map_resources()
 
     if auth_mode == "conf":

--- a/oneview_redfish_toolkit/client_session.py
+++ b/oneview_redfish_toolkit/client_session.py
@@ -63,13 +63,16 @@ def _gc_for_expired_sessions():
     map_items = _get_map_clients().items()
     for token, dict_by_token in map_items:
         ov_clients = iter(dict_by_token['client_ov_by_ip'].values())
-        ov_client = next(ov_clients)
+        ov_client = next(ov_clients)  # ov_clients can be in any order
+        ov_session_id = ov_client.connection.get_session_id()
         try:
             # request that does not increment the life of Oneview session
-            resp, body = ov_client.connection.do_http('GET',
-                                                      '/rest/sessions/',
-                                                      '',
-                                                      {'Session-Id': token})
+            resp, body = ov_client.connection.do_http(
+                'GET',
+                '/rest/sessions/',
+                '',
+                {'Session-Id': ov_session_id}
+            )
 
             # when is not a success
             if resp.status not in range(200, 300):

--- a/oneview_redfish_toolkit/client_session.py
+++ b/oneview_redfish_toolkit/client_session.py
@@ -18,7 +18,9 @@
 from collections import OrderedDict
 import logging
 import logging.config
+import threading
 from threading import Lock
+import time
 import uuid
 
 # 3rd party libs
@@ -36,12 +38,55 @@ from oneview_redfish_toolkit import connection
 #   globals()['map_clients']
 
 
+GC_FREQUENCY_IN_SEC = 12 * 60 * 60
+
+
 def _get_map_clients():
     return globals()['map_clients']
 
 
 def init_map_clients():
     globals()['map_clients'] = OrderedDict()
+
+
+def init_gc_for_expired_sessions():
+    gc_thread = threading.Thread(target=_gc_for_expired_sessions)
+    gc_thread.daemon = True
+    gc_thread.start()
+
+
+def _gc_for_expired_sessions():
+    time.sleep(GC_FREQUENCY_IN_SEC)
+    logging.info('Verifying expired sessions...')
+
+    tokens_to_remove = []
+    map_items = _get_map_clients().items()
+    for token, dict_by_token in map_items:
+        ov_clients = iter(dict_by_token['client_ov_by_ip'].values())
+        ov_client = next(ov_clients)
+        try:
+            # request that does not increment the life of Oneview session
+            resp, body = ov_client.connection.do_http('GET',
+                                                      '/rest/sessions/',
+                                                      '',
+                                                      {'Session-Id': token})
+
+            # when is not a success
+            if resp.status not in range(200, 300):
+                if resp.status == 404:
+                    tokens_to_remove.append(token)
+                else:
+                    logging.error('Unexpected response with status {} '
+                                  'of Oneview sessions endpoint: {}'
+                                  .format(resp.status, body))
+
+        except Exception as e:
+            logging.exception('Unexpected error: {}'.format(e))
+
+    for token in tokens_to_remove:
+        clear_session_by_token(token)
+
+    _gc_for_expired_sessions()
 
 
 def _set_new_client_by_token(redfish_token, client_ov_by_ip):

--- a/oneview_redfish_toolkit/tests/test_client_session.py
+++ b/oneview_redfish_toolkit/tests/test_client_session.py
@@ -185,6 +185,9 @@ class TestAuthentication(unittest.TestCase):
         resp_2 = mock.Mock(status=404)
         uuid_mock.uuid4.side_effect = ['session_id_1', 'session_id_2']
 
+        client_1.connection.get_session_id.return_value = 'ov_session_abc'
+        client_2.connection.get_session_id.return_value = 'ov_session_def'
+
         client_1.connection.do_http.return_value = (resp_1, None)
         client_2.connection.do_http.return_value = (resp_2, None)
 
@@ -212,11 +215,13 @@ class TestAuthentication(unittest.TestCase):
         client_1.connection.do_http.assert_called_with('GET',
                                                        '/rest/sessions/',
                                                        '',
-                                                       {'Session-Id': 'abc'})
+                                                       {'Session-Id':
+                                                        'ov_session_abc'})
         client_2.connection.do_http.assert_called_with('GET',
                                                        '/rest/sessions/',
                                                        '',
-                                                       {'Session-Id': 'def'})
+                                                       {'Session-Id':
+                                                        'ov_session_def'})
 
     @mock.patch.object(client_session, 'time')
     def test_garbage_collector_recursion(self, time_mock):


### PR DESCRIPTION
- Starts a Thread that every 12 hours looks for expired and abandoned sessions tokens, and remove them from cache.

Closes #441 

### How test the solution? ###
You can change the expiration time of a specific session in Oneview, just apply a request like below (changing the ONEVIEW_IP and ONEVIEW_TOKEN to valid values):
```bash
curl -X POST \
  https://ONEVIEW_IP/rest/sessions/idle-timeout \
  -H 'auth: ONEVIEW_TOKEN' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'session-id: ONEVIEW_TOKEN' \
  -H 'x-api-version: 600' \
  -d '{ "idleTimeout": 60000 }'
```
The `idleTimeout` is the value in **milliseconds** to keep alive the session.
For our example above, 60000 is the time to keep alive during 1 minute.

Steps to test:
1) Create more than one session on Redfish server.
2) List the Redfish sessions accessing `/redfish/v1/SessionService/Sessions`
3) Post a request to change the session `idleTimeout` to the Oneview server
4) Wait the time to expire Oneview session based on idleTimeout
5) List the Redfish sessions again. You should see one session less than previously.  
