### PR TITLE
Adds logs: info about how many OV and Redfish resources for Zone and Zone Collection

### DIFF
--- a/oneview_redfish_toolkit/blueprints/zone.py
+++ b/oneview_redfish_toolkit/blueprints/zone.py
@@ -21,6 +21,9 @@ from oneview_redfish_toolkit.api.zone import Zone
 from oneview_redfish_toolkit.api.zone_collection import ZoneCollection
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
+from oneview_redfish_toolkit.services import logging_service
+from oneview_redfish_toolkit.services.logging_service import \
+    COUNTER_LOGGER_NAME
 from oneview_redfish_toolkit.services.zone_service import ZoneService
 
 zone = Blueprint("zone", __name__)
@@ -67,6 +70,14 @@ def get_zone(zone_uuid):
 
     zone_data = Zone(zone_uuid, profile_template, server_hardware_list,
                      enclosure_name, drives)
+
+    sh_count = len(server_hardware_list)
+    blocks_count = len(zone_data.redfish["Links"]["ResourceBlocks"])
+    logging_service.debug(
+        COUNTER_LOGGER_NAME,
+        "Drives retrieved: " + str(len(drives)),
+        "ServerHardware retrieved: " + str(sh_count),
+        "ResourceBlocks listed on Zone: " + str(blocks_count))
 
     return ResponseBuilder.success(zone_data)
 

--- a/oneview_redfish_toolkit/blueprints/zone_collection.py
+++ b/oneview_redfish_toolkit/blueprints/zone_collection.py
@@ -20,6 +20,9 @@ from flask import g
 from oneview_redfish_toolkit.api.zone_collection import ZoneCollection
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
+from oneview_redfish_toolkit.services import logging_service
+from oneview_redfish_toolkit.services.logging_service import \
+    COUNTER_LOGGER_NAME
 from oneview_redfish_toolkit.services.zone_service import ZoneService
 
 zone_collection = Blueprint("zone_collection", __name__)
@@ -45,5 +48,12 @@ def get_zone_collection():
     zone_ids = zone_service.get_zone_ids_by_templates(server_profile_templates)
 
     zc = ZoneCollection(zone_ids)
+
+    spt_count = len(server_profile_templates)
+    zone_count = len(zc.redfish["Members"])
+    logging_service.debug(
+        COUNTER_LOGGER_NAME,
+        "ServerProfileTemplates retrieved: " + str(spt_count),
+        "Zones listed: " + str(zone_count))
 
     return ResponseBuilder.success(zc)

--- a/oneview_redfish_toolkit/services/logging_service.py
+++ b/oneview_redfish_toolkit/services/logging_service.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import threading
+
+COUNTER_LOGGER_NAME = 'qtty'
+
+
+def debug(logger_name, *texts):
+    if logging.getLogger().isEnabledFor(logging.DEBUG):
+        msg = "Thread {}: ".format(threading.get_ident())
+        msg += ", ".join(texts)
+        logger = logging.getLogger(logger_name)
+        logger.debug(msg)

--- a/oneview_redfish_toolkit/services/zone_service.py
+++ b/oneview_redfish_toolkit/services/zone_service.py
@@ -15,6 +15,9 @@
 # under the License.
 from oneview_redfish_toolkit.services.computer_system_service import \
     ComputerSystemService
+from oneview_redfish_toolkit.services import logging_service
+from oneview_redfish_toolkit.services.logging_service import \
+    COUNTER_LOGGER_NAME
 
 
 class ZoneService(object):
@@ -119,6 +122,7 @@ class ZoneService(object):
     def _get_enclosures_uris_with_valid_drive_enclosures(self):
         all_enclosures_uris = [enclosure["uri"] for enclosure in
                                self.ov_client.enclosures.get_all()]
+
         valid_enclosures_uris = list()
 
         for enclosure_uri in all_enclosures_uris:
@@ -128,5 +132,11 @@ class ZoneService(object):
             for drive_enclosure in drive_enclosures:
                 if drive_enclosure["driveBays"]:
                     valid_enclosures_uris.append(enclosure_uri)
+
+        encl_count = len(all_enclosures_uris)
+        valid_encl_count = len(valid_enclosures_uris)
+        logging_service.debug(COUNTER_LOGGER_NAME,
+                              "Enclosures retrieved: " + str(encl_count),
+                              "Valid Enclosures: " + str(valid_encl_count))
 
         return valid_enclosures_uris


### PR DESCRIPTION
Closes #447 

The prefix of that new logs is `counter` and just is logged in debug level.

This is a example of result in log after the commit:
```
2018-09-18 17:12:39,859 - root - WARNING - Authentication mode set to session. SCMB events will be disabled
2018-09-18 17:12:39,860 - root - WARNING - Server is starting with a self-signed certificate.
2018-09-18 17:12:39,864 - root - WARNING - Using existing self-signed certs
2018-09-18 17:12:47,827 - root - DEBUG - AuthLoginDomain not specified on session creation
2018-09-18 17:12:49,835 - perf - DEBUG - Thread 140382398568192 OneView process: 0
2018-09-18 17:12:49,836 - perf - DEBUG - Thread 140382398568192 Redfish process: 2.008012294769287
2018-09-18 17:12:49,838 - perf - DEBUG - Thread 140382398568192 Total process: 2.008012294769287
2018-09-18 17:12:49,840 - wsgi - INFO - 172.17.0.1 - - [18/Sep/2018:17:12:47 +0000] "POST /redfish/v1/SessionService/Sessions HTTP/1.1" 200 282 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"
2018-09-18 17:13:01,474 - perf - DEBUG - Thread 140382381782784 OneView request: server_profile_templates.get_all: 0.7899947166442871
2018-09-18 17:13:02,636 - perf - DEBUG - Thread 140382381782784 OneView request: enclosures.get_all: 1.1599185466766357
2018-09-18 17:13:04,023 - perf - DEBUG - Thread 140382381782784 OneView request: drive_enclosures.get_all: 1.383301019668579
2018-09-18 17:13:05,458 - perf - DEBUG - Thread 140382381782784 OneView request: drive_enclosures.get_all: 1.4339520931243896
2018-09-18 17:13:06,948 - perf - DEBUG - Thread 140382381782784 OneView request: drive_enclosures.get_all: 1.4877748489379883
2018-09-18 17:13:06,949 - qtty - DEBUG - Thread 140382381782784: Enclosures retrieved: 3, Valid Enclosures: 3
2018-09-18 17:13:07,772 - perf - DEBUG - Thread 140382381782784 OneView request: connection.get: 0.8212437629699707
2018-09-18 17:13:08,548 - perf - DEBUG - Thread 140382381782784 OneView request: logical_enclosures.get: 0.7734317779541016
2018-09-18 17:13:09,353 - perf - DEBUG - Thread 140382381782784 OneView request: connection.get: 0.8026919364929199
2018-09-18 17:13:10,152 - perf - DEBUG - Thread 140382381782784 OneView request: logical_enclosures.get: 0.7964508533477783
2018-09-18 17:13:10,167 - qtty - DEBUG - Thread 140382381782784: ServerProfileTemplates retrieved: 5, Zones listed: 9
2018-09-18 17:13:10,170 - perf - DEBUG - Thread 140382381782784 OneView process: 9.44875955581665
2018-09-18 17:13:10,171 - perf - DEBUG - Thread 140382381782784 Redfish process: 0.0368657112121582
2018-09-18 17:13:10,172 - perf - DEBUG - Thread 140382381782784 Total process: 9.485625267028809
2018-09-18 17:13:10,174 - wsgi - INFO - 172.17.0.1 - - [18/Sep/2018:17:13:00 +0000] "GET /redfish/v1/CompositionService/ResourceZones HTTP/1.1" 200 1562 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"
2018-09-18 17:13:29,670 - perf - DEBUG - Thread 140382364997376 OneView request: server_profile_templates.get: 0.7337296009063721
2018-09-18 17:13:30,598 - perf - DEBUG - Thread 140382364997376 OneView request: enclosures.get: 0.9197821617126465
2018-09-18 17:13:31,417 - perf - DEBUG - Thread 140382364997376 OneView request: connection.get: 0.8159365653991699
2018-09-18 17:13:32,724 - perf - DEBUG - Thread 140382364997376 OneView request: connection.get: 1.3046398162841797
2018-09-18 17:13:33,587 - perf - DEBUG - Thread 140382364997376 OneView request: server_hardware.get_all: 0.8603379726409912
2018-09-18 17:13:33,608 - qtty - DEBUG - Thread 140382364997376:  Drives retrieved: 40, ServerHardware retrieved: 1, ResourceBlocks listed on Zone: 42
2018-09-18 17:13:33,610 - perf - DEBUG - Thread 140382364997376 OneView process: 4.634426116943359
2018-09-18 17:13:33,611 - perf - DEBUG - Thread 140382364997376 Redfish process: 0.039423465728759766
2018-09-18 17:13:33,612 - perf - DEBUG - Thread 140382364997376 Total process: 4.673849582672119
2018-09-18 17:13:33,613 - wsgi - INFO - 172.17.0.1 - - [18/Sep/2018:17:13:28 +0000] "GET /redfish/v1/CompositionService/ResourceZones/61c3a463-1355-4c68-a4e3-4f08c322af1b-0000000000A66101 HTTP/1.1" 200 7008 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36"
```