### PR TITLE
Update @Redfish.Copyright attribute adding 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright 2017 Hewlett Packard Enterprise
+Copyright 2017-2018 Hewlett Packard Enterprise
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/oneview_redfish_toolkit/api/chassis_collection.py
+++ b/oneview_redfish_toolkit/api/chassis_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/errors.py
+++ b/oneview_redfish_toolkit/api/errors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/manager_collection.py
+++ b/oneview_redfish_toolkit/api/manager_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/network_adapter_collection.py
+++ b/oneview_redfish_toolkit/api/network_adapter_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/network_device_function.py
+++ b/oneview_redfish_toolkit/api/network_device_function.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/network_device_function_collection.py
+++ b/oneview_redfish_toolkit/api/network_device_function_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/network_port.py
+++ b/oneview_redfish_toolkit/api/network_port.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/network_port_collection.py
+++ b/oneview_redfish_toolkit/api/network_port_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/service_root.py
+++ b/oneview_redfish_toolkit/api/service_root.py
@@ -71,7 +71,7 @@ class ServiceRoot(RedfishJsonValidator):
             "/redfish/v1/$metadata#ServiceRoot.ServiceRoot"
         self.redfish["@odata.id"] = "/redfish/v1/"
         self.redfish["@Redfish.Copyright"] = \
-            "Copyright (2017) Hewlett Packard Enterprise Development LP"
+            "Copyright (2017-2018) Hewlett Packard Enterprise Development LP"
 
         self._validate()
 

--- a/oneview_redfish_toolkit/api/subscription_collection.py
+++ b/oneview_redfish_toolkit/api/subscription_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/api/thermal.py
+++ b/oneview_redfish_toolkit/api/thermal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/blueprints/manager.py
+++ b/oneview_redfish_toolkit/blueprints/manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/blueprints/metadata.py
+++ b/oneview_redfish_toolkit/blueprints/metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/blueprints/service_root.py
+++ b/oneview_redfish_toolkit/blueprints/service_root.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/mockups/redfish/ServiceRoot.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ServiceRoot.json
@@ -26,5 +26,5 @@
     },
     "@odata.context": "/redfish/v1/$metadata#ServiceRoot.ServiceRoot",
     "@odata.id": "/redfish/v1/",
-    "@Redfish.Copyright": "Copyright (2017) Hewlett Packard Enterprise Development LP"
+    "@Redfish.Copyright": "Copyright (2017-2018) Hewlett Packard Enterprise Development LP"
 }

--- a/oneview_redfish_toolkit/tests/api/test_blade_chassis.py
+++ b/oneview_redfish_toolkit/tests/api/test_blade_chassis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_blade_manager.py
+++ b/oneview_redfish_toolkit/tests/api/test_blade_manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_chassis_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_chassis_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_enclosure_chassis.py
+++ b/oneview_redfish_toolkit/tests/api/test_enclosure_chassis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_enclosure_manager.py
+++ b/oneview_redfish_toolkit/tests/api/test_enclosure_manager.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_manager_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_manager_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_metadata.py
+++ b/oneview_redfish_toolkit/tests/api/test_metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_adapter.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_adapter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_adapter_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_adapter_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_device_function.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_device_function.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_device_function_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_device_function_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_port.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_port.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_network_port_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_port_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_odata.py
+++ b/oneview_redfish_toolkit/tests/api/test_odata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_rack_chassis.py
+++ b/oneview_redfish_toolkit/tests/api/test_rack_chassis.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_redfish_error.py
+++ b/oneview_redfish_toolkit/tests/api/test_redfish_error.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
+++ b/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_service_root.py
+++ b/oneview_redfish_toolkit/tests/api/test_service_root.py
@@ -52,4 +52,5 @@ class TestServiceRoot(BaseTest):
             'oneview_redfish_toolkit/mockups/redfish/ServiceRoot.json'
         ) as f:
             service_root_mockup = json.load(f)
+
         self.assertEqualMockup(service_root_mockup, result)

--- a/oneview_redfish_toolkit/tests/api/test_subscription.py
+++ b/oneview_redfish_toolkit/tests/api/test_subscription.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_subscription_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_subscription_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/oneview_redfish_toolkit/tests/api/test_thermal.py
+++ b/oneview_redfish_toolkit/tests/api/test_thermal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain


### PR DESCRIPTION
- Calling the base redfish REST (/redfish/v1/) returns copyright properly
- Adds 2018 in all files that were changed in this year.

Closes #333 