### PR TITLE
Performance improvement on ResourceBlock OneView data request

### DIFF
--- a/oneview_redfish_toolkit/mockups/redfish/ComputerSystemCollection.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ComputerSystemCollection.json
@@ -30,9 +30,6 @@
                         },
                         {
                             "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102"
-                        },
-                        {
-                            "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103"
                         }
                     ],
                     "TargetCollection": {

--- a/oneview_redfish_toolkit/mockups/redfish/ServerHardwareResourceBlock.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ServerHardwareResourceBlock.json
@@ -28,9 +28,6 @@
     ],
     "Zones": [
       {
-        "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103"
-      },
-      {
         "@odata.id": "/redfish/v1/CompositionService/ResourceZones/75871d70-789e-4cf9-8bc8-6f4d73193578"
       }
     ],

--- a/oneview_redfish_toolkit/mockups/redfish/ServerProfileTemplateResourceBlock.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ServerProfileTemplateResourceBlock.json
@@ -24,9 +24,6 @@
         },
         {
           "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102"
-        },
-        {
-          "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103"
         }
       ]
     }

--- a/oneview_redfish_toolkit/mockups/redfish/ZoneCollection.json
+++ b/oneview_redfish_toolkit/mockups/redfish/ZoneCollection.json
@@ -1,16 +1,13 @@
 {
   "@odata.type": "#ZoneCollection.ZoneCollection",
   "Name": "Resource Zone Collection",
-  "Members@odata.count": 4,
+  "Members@odata.count": 3,
   "Members": [
     {
       "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66101"
     },
     {
       "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102"
-    },
-    {
-      "@odata.id": "/redfish/v1/CompositionService/ResourceZones/1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103"
     },
     {
       "@odata.id": "/redfish/v1/CompositionService/ResourceZones/75871d70-789e-4cf9-8bc8-6f4d73193578"

--- a/oneview_redfish_toolkit/services/zone_service.py
+++ b/oneview_redfish_toolkit/services/zone_service.py
@@ -120,23 +120,24 @@ class ZoneService(object):
         return zone_ids
 
     def _get_enclosures_uris_with_valid_drive_enclosures(self):
-        all_enclosures_uris = [enclosure["uri"] for enclosure in
-                               self.ov_client.enclosures.get_all()]
-
         valid_enclosures_uris = list()
+        drive_enclosures_list = self.ov_client.drive_enclosures.get_all()
 
-        for enclosure_uri in all_enclosures_uris:
-            drive_enclosures = self.ov_client.drive_enclosures.get_all(
-                filter="locationUri='{}'".format(enclosure_uri))
-
-            for drive_enclosure in drive_enclosures:
-                if drive_enclosure["driveBays"]:
-                    valid_enclosures_uris.append(enclosure_uri)
-
-        encl_count = len(all_enclosures_uris)
+        for drive_encl in drive_enclosures_list:
+            # Check if have valid driver enclosure
+            if drive_encl["driveBays"]:
+                # Get enclosure uri from driver enclosure
+                for location_entry in \
+                    drive_encl['driveEnclosureLocation']['locationEntries']:
+                    if location_entry['type'] == 'Enclosure':
+                        valid_enclosures_uris.append(location_entry['value'])
+                        break
+        
+        drive_encl_count = len(drive_enclosures_list)
         valid_encl_count = len(valid_enclosures_uris)
         logging_service.debug(COUNTER_LOGGER_NAME,
-                              "Enclosures retrieved: " + str(encl_count),
+                              "Drive Enclosures retrieved: " +
+                              str(drive_encl_count),
                               "Valid Enclosures: " + str(valid_encl_count))
 
         return valid_enclosures_uris

--- a/oneview_redfish_toolkit/services/zone_service.py
+++ b/oneview_redfish_toolkit/services/zone_service.py
@@ -132,7 +132,7 @@ class ZoneService(object):
                     if location_entry['type'] == 'Enclosure':
                         valid_enclosures_uris.append(location_entry['value'])
                         break
-        
+
         drive_encl_count = len(drive_enclosures_list)
         valid_encl_count = len(valid_enclosures_uris)
         logging_service.debug(COUNTER_LOGGER_NAME,

--- a/oneview_redfish_toolkit/tests/api/test_computer_system_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_computer_system_collection.py
@@ -58,7 +58,6 @@ class TestComputerSystemCollection(BaseTest):
         zone_ids = [
             "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66101",
             "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102",
-            "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103",
             "75871d70-789e-4cf9-8bc8-6f4d73193578"
         ]
 

--- a/oneview_redfish_toolkit/tests/api/test_server_hardware_resource_block.py
+++ b/oneview_redfish_toolkit/tests/api/test_server_hardware_resource_block.py
@@ -46,7 +46,6 @@ class TestServerHardwareResourceBlock(BaseTest):
         zone_ids = [
             "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66101",
             "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102",
-            "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103",
             "75871d70-789e-4cf9-8bc8-6f4d73193578",
         ]
 

--- a/oneview_redfish_toolkit/tests/api/test_server_profile_template_resource_block.py
+++ b/oneview_redfish_toolkit/tests/api/test_server_profile_template_resource_block.py
@@ -41,8 +41,7 @@ class TestServerProfileTemplateResourceBlock(BaseTest):
 
         zone_ids = [
             "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66101",
-            "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102",
-            "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103"
+            "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102"
         ]
 
         resource_block = ServerProfileTemplateResourceBlock(

--- a/oneview_redfish_toolkit/tests/api/test_zone_collection.py
+++ b/oneview_redfish_toolkit/tests/api/test_zone_collection.py
@@ -33,7 +33,6 @@ class TestZoneCollection(BaseTest):
 
         zone_ids = ["1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66101",
                     "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66102",
-                    "1f0ca9ef-7f81-45e3-9d64-341b46cf87e0-0000000000A66103",
                     "75871d70-789e-4cf9-8bc8-6f4d73193578"]
 
         zone_collection = ZoneCollection(zone_ids)

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
@@ -111,13 +111,6 @@ class TestComputerSystemCollection(BaseFlaskTest):
                 'DriveEnclosureList.json'
         ) as f:
             drive_enclosure = json.load(f)
-
-        with open(
-                'oneview_redfish_toolkit/mockups/oneview/'
-                'Enclosures.json'
-        ) as f:
-            enclosures = json.load(f)
-
         self.oneview_client.server_hardware.get_all.return_value = \
             server_hardware_list
 
@@ -130,7 +123,6 @@ class TestComputerSystemCollection(BaseFlaskTest):
             .return_value = logical_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             drive_enclosure
-        self.oneview_client.enclosures.get_all.return_value = enclosures
 
         response = self.client.get("/redfish/v1/Systems/")
 

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
@@ -152,6 +152,4 @@ class TestComputerSystemCollection(BaseFlaskTest):
             + "&category=logical-enclosures")
         self.oneview_client.logical_enclosures.get.assert_called_with(
             logical_encl["uri"])
-        self.oneview_client.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        self.oneview_client.enclosures.get_all.assert_called_with()
+        self.oneview_client.drive_enclosures.get_all.assert_called_with()

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -169,9 +169,7 @@ class TestResourceBlock(BaseFlaskTest):
             server_profile_templates.get_all.assert_called_with()
         self.oneview_client.logical_enclosures.get.assert_called_with(
             self.log_encl["uri"])
-        self.oneview_client.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        self.oneview_client.enclosures.get_all.assert_called_with()
+        self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_storage_resource_block_when_drive_is_composed(self):
         with open(
@@ -224,9 +222,7 @@ class TestResourceBlock(BaseFlaskTest):
             server_profile_templates.get_all.assert_called_with()
         self.oneview_client.logical_enclosures.get.assert_called_with(
             self.log_encl["uri"])
-        self.oneview_client.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        self.oneview_client.enclosures.get_all.assert_called_with()
+        self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_server_hardware_resource_block(self):
         self.oneview_client.server_hardware.get.return_value = \
@@ -382,9 +378,7 @@ class TestResourceBlock(BaseFlaskTest):
                 )
         self.oneview_client.logical_enclosures.get.assert_called_with(
             self.log_encl["uri"])
-        self.oneview_client.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        self.oneview_client.enclosures.get_all.assert_called_with()
+        self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_spt_resource_block(self):
         with open(
@@ -416,9 +410,7 @@ class TestResourceBlock(BaseFlaskTest):
 
         self.oneview_client.logical_enclosures.get.assert_called_with(
             self.log_encl["uri"])
-        self.oneview_client.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        self.oneview_client.enclosures.get_all.assert_called_with()
+        self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_spt_resource_when_template_has_not_valid_controller(self):
         with open(

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -91,12 +91,6 @@ class TestResourceBlock(BaseFlaskTest):
 
         with open(
                 'oneview_redfish_toolkit/mockups/oneview'
-                '/Enclosures.json'
-        ) as f:
-            self.enclosures = json.load(f)
-
-        with open(
-                'oneview_redfish_toolkit/mockups/oneview'
                 '/DriveEnclosureList.json'
         ) as f:
             self.drive_enclosure_list = json.load(f)
@@ -142,7 +136,6 @@ class TestResourceBlock(BaseFlaskTest):
             logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceBlocks"
@@ -195,7 +188,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceBlocks"
@@ -234,7 +226,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceBlocks"
@@ -256,7 +247,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         for oneview_state, redfish_state in status_mapping.\
                 SERVER_HARDWARE_STATE_TO_REDFISH_STATE_MAPPING.items():
@@ -298,7 +288,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         for oneview_state, redfish_state in status_mapping.\
                 SERVER_HARDWARE_STATE_TO_REDFISH_STATE_MAPPING.items():
@@ -340,7 +329,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         for oneview_status, redfish_status in \
                 status_mapping.HEALTH_STATE_MAPPING.items():
@@ -396,7 +384,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.logical_enclosures.get.return_value = self.log_encl
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        self.oneview_client.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceBlocks"

--- a/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
@@ -56,12 +56,6 @@ class TestZoneCollection(BaseFlaskTest):
 
         with open(
                 'oneview_redfish_toolkit/mockups/oneview'
-                '/Enclosures.json'
-        ) as f:
-            self.enclosures = json.load(f)
-
-        with open(
-                'oneview_redfish_toolkit/mockups/oneview'
                 '/DriveEnclosureList.json'
         ) as f:
             self.drive_enclosure_list = json.load(f)
@@ -100,7 +94,6 @@ class TestZoneCollection(BaseFlaskTest):
             self.server_profile_template_list
         ov_api.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
-        ov_api.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceZones/")
@@ -197,7 +190,6 @@ class TestZoneCollection(BaseFlaskTest):
             self.server_profile_template_list
         ov_api.drive_enclosures.get_all.return_value = \
             drive_enclosure_list
-        ov_api.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceZones/")

--- a/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
@@ -123,9 +123,7 @@ class TestZoneCollection(BaseFlaskTest):
             + "&category=logical-enclosures")
         ov_api.logical_enclosures.get.assert_called_with(
             self.logical_encl["uri"])
-        ov_api.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        ov_api.enclosures.get_all.assert_called_with()
+        ov_api.drive_enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_empty(self):
         """Tests ZoneCollection with an empty list"""
@@ -154,12 +152,11 @@ class TestZoneCollection(BaseFlaskTest):
 
         zone_collection_mockup = copy.deepcopy(self.zone_collection_mockup)
         zone_collection_mockup["Members@odata.count"] = 1
-        del zone_collection_mockup["Members"][:3]
+        del zone_collection_mockup["Members"][:2]
 
         ov_api.server_profile_templates.get_all.return_value = \
             self.server_profile_template_list
         ov_api.drive_enclosures.get_all.return_value = []
-        ov_api.enclosures.get_all.return_value = self.enclosures
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceZones/")
@@ -181,9 +178,7 @@ class TestZoneCollection(BaseFlaskTest):
             + "&category=logical-enclosures")
         ov_api.logical_enclosures.get.assert_called_with(
             self.logical_encl["uri"])
-        ov_api.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        ov_api.enclosures.get_all.assert_called_with()
+        ov_api.drive_enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_with_drive_enclosure_without_drives(self):
         ov_api = self.oneview_client
@@ -193,7 +188,7 @@ class TestZoneCollection(BaseFlaskTest):
 
         zone_collection_mockup = copy.deepcopy(self.zone_collection_mockup)
         zone_collection_mockup["Members@odata.count"] = 1
-        del zone_collection_mockup["Members"][:3]
+        del zone_collection_mockup["Members"][:2]
         drive_enclosure_list = copy.deepcopy(self.drive_enclosure_list)
         del drive_enclosure_list[:1]
         drive_enclosure_list[0]["driveBays"] = 0
@@ -225,6 +220,4 @@ class TestZoneCollection(BaseFlaskTest):
             + "&category=logical-enclosures")
         ov_api.logical_enclosures.get.assert_called_with(
             self.logical_encl["uri"])
-        ov_api.drive_enclosures.get_all.assert_called_with(
-            filter="locationUri='/rest/enclosures/0000000000A66101'")
-        ov_api.enclosures.get_all.assert_called_with()
+        ov_api.drive_enclosures.get_all.assert_called_with()


### PR DESCRIPTION
Closes partially #428 

Previously the application did **1 + N** requests to retrieve the enclosures URI with valid drive enclosures, which **N** is the number of enclosures on OneView.
Now the application just need **1** request to retrieve this data.

These requests is performed for the Resource Block GET request.
We have an average reduction of **3** OneView requests per Resource Block GET request.

Below there is a graph comparing previous and currently performance with the elapsed time to retrieve each one of all 111 Resource Blocks on the DCS that we have:
![resource_block_performance](https://user-images.githubusercontent.com/20116439/45844865-f9492880-bcf9-11e8-848b-c79526cc75de.png)

This improvement also impacts on ResourseZoneCollection and ComputerSystemCollection.

