### PR TITLE
Performance improvement for Resource Block

### DIFF
--- a/oneview_redfish_toolkit/handler_multiple_oneview.py
+++ b/oneview_redfish_toolkit/handler_multiple_oneview.py
@@ -46,7 +46,10 @@ RESOURCE_STRATEGY = {
         "get": st.first_parameter_resource,
         "get_all": st.filter_uuid_parameter_resource,
         },
-    "logical_enclosures": {"get": st.first_parameter_resource},
+    "logical_enclosures": {
+        "get": st.first_parameter_resource,
+        "get_all": st.all_oneviews_resource,
+        },
     "network_sets": {"get": st.first_parameter_resource},
     "racks": {
         "get": st.first_parameter_resource,

--- a/oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json
+++ b/oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json
@@ -1,0 +1,178 @@
+[
+    {
+        "type": "LogicalEnclosureV4",
+        "enclosureGroupUri": "/rest/enclosure-groups/bc41f38d-e8ce-4241-acd1-00b2d8c5d0fa",
+        "enclosureUris": [
+            "/rest/enclosures/0000000000A66101",
+            "/rest/enclosures/0000000000A66102",
+            "/rest/enclosures/0000000000A66103"
+        ],
+        "enclosures": {
+            "/rest/enclosures/0000000000A66101": {
+                "enclosureUri": "/rest/enclosures/0000000000A66101",
+                "interconnectBays": [
+                    {
+                        "bayNumber": 1,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 2,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 3,
+                        "licenseIntents": {
+                            "FCUpgrade": "Automatic"
+                        }
+                    },
+                    {
+                        "bayNumber": 4,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 5,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 6,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    }
+                ]
+            },
+            "/rest/enclosures/0000000000A66102": {
+                "enclosureUri": "/rest/enclosures/0000000000A66102",
+                "interconnectBays": [
+                    {
+                        "bayNumber": 1,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 2,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 3,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 4,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 5,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 6,
+                        "licenseIntents": {
+                            "FCUpgrade": "Automatic"
+                        }
+                    }
+                ]
+            },
+            "/rest/enclosures/0000000000A66103": {
+                "enclosureUri": "/rest/enclosures/0000000000A66103",
+                "interconnectBays": [
+                    {
+                        "bayNumber": 1,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 2,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 3,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 4,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 5,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    },
+                    {
+                        "bayNumber": 6,
+                        "licenseIntents": {
+                            "FCUpgrade": "No"
+                        }
+                    }
+                ]
+            }
+        },
+        "logicalInterconnectUris": [
+            "/rest/logical-interconnects/299da236-4137-4914-9bb7-c62d08ebe027",
+            "/rest/logical-interconnects/a2b731b9-75a2-4288-b003-436588670f03",
+            "/rest/logical-interconnects/a50aa449-5dea-4095-85e0-899b2a7ec193",
+            "/rest/logical-interconnects/fe4967cc-bdf3-4a8c-a7de-e5141f7a718c",
+            "/rest/sas-logical-interconnects/63138084-6d81-4b50-b35b-7e01a2390636",
+            "/rest/sas-logical-interconnects/9edd4c86-37b8-4e54-bbf6-87970d88c450",
+            "/rest/sas-logical-interconnects/eb1f4e42-2a82-45b2-8f6c-2be66ff7eeb3"
+        ],
+        "ipAddressingMode": "External",
+        "ipv4Ranges": [],
+        "powerMode": "RedundantPowerFeed",
+        "ambientTemperatureMode": "Standard",
+        "firmware": {
+            "firmwareBaselineUri": null,
+            "forceInstallFirmware": false,
+            "updateFirmwareOnUnmanagedInterconnect": false,
+            "logicalInterconnectUpdateMode": "Parallel",
+            "validateIfLIFirmwareUpdateIsNonDisruptive": false
+        },
+        "scalingState": "NotScaling",
+        "uri": "/rest/logical-enclosures/82431b7d-bc11-4d0b-a158-40b71071284c",
+        "category": "logical-enclosures",
+        "eTag": "2018-09-17T13:52:23.594Z",
+        "created": "2018-05-10T19:08:24.072Z",
+        "modified": "2018-09-17T13:52:23.594Z",
+        "deleteFailed": false,
+        "deploymentManagerSettings": {
+            "deploymentClusterUri": null,
+            "osDeploymentSettings": {
+                "manageOSDeployment": false,
+                "deploymentModeSettings": {
+                    "deploymentMode": "None",
+                    "deploymentNetworkUri": null
+                }
+            }
+        },
+        "scopesUri": "/rest/scopes/resources/rest/logical-enclosures/82431b7d-bc11-4d0b-a158-40b71071284c",
+        "state": "Consistent",
+        "status": "OK",
+        "name": "test_le1",
+        "description": null
+    }
+]

--- a/oneview_redfish_toolkit/services/zone_service.py
+++ b/oneview_redfish_toolkit/services/zone_service.py
@@ -72,10 +72,11 @@ class ZoneService(object):
         return template_id, enclosure_id
 
     def _get_enclosures_uris_by_template(self, server_profile_template,
-            logical_encl_list):
+                                         logical_encl_list):
         enclosure_uris = []
         for logical_encl in logical_encl_list:
-            if logical_encl['enclosureGroupUri'] == server_profile_template['enclosureGroupUri']:
+            if logical_encl['enclosureGroupUri'] == \
+                server_profile_template['enclosureGroupUri']:
                 enclosure_uris += logical_encl['enclosureUris']
 
         #  the set keeps the elements without repetition

--- a/oneview_redfish_toolkit/services/zone_service.py
+++ b/oneview_redfish_toolkit/services/zone_service.py
@@ -73,19 +73,10 @@ class ZoneService(object):
 
     def _get_enclosures_uris_by_template(self, server_profile_template,
             logical_encl_list):
-        log_encl_assoc_uri = "/rest/index/associations/resources" \
-                             "?parenturi={}&category=logical-enclosures" \
-            .format(server_profile_template["enclosureGroupUri"])
-        logical_encl_assoc = self.ov_client.connection.get(
-            log_encl_assoc_uri)
-        members = logical_encl_assoc["members"]
         enclosure_uris = []
-        for member in members:
-            # Look for the logical enclosure on list of all logical enclosures
-            for logical_encl in logical_encl_list:
-                if logical_encl['uri'] == member['childResource']['uri']:
-                    enclosure_uris += logical_encl['enclosureUris']
-                    break
+        for logical_encl in logical_encl_list:
+            if logical_encl['enclosureGroupUri'] == server_profile_template['enclosureGroupUri']:
+                enclosure_uris += logical_encl['enclosureUris']
 
         #  the set keeps the elements without repetition
         enclosure_uris = list(set(enclosure_uris))

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
@@ -131,4 +131,3 @@ class TestComputerSystemCollection(BaseFlaskTest):
 
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
         self.oneview_client.logical_enclosures.get_all.assert_called_with()
-        self.oneview_client.enclosures.get_all.assert_called_with()

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system_collection.py
@@ -90,15 +90,9 @@ class TestComputerSystemCollection(BaseFlaskTest):
             server_profile_template_list = json.load(f)
 
         with open(
-            'oneview_redfish_toolkit/mockups/oneview/'
-            'LogicalEnclByIndexAssociationWithEnclGroup.json'
+            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json'
         ) as f:
-            logical_encl_assoc = json.load(f)
-
-        with open(
-            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosure.json'
-        ) as f:
-            logical_encl = json.load(f)
+            logical_encl_list = json.load(f)
 
         with open(
                 'oneview_redfish_toolkit/mockups/redfish/'
@@ -117,10 +111,8 @@ class TestComputerSystemCollection(BaseFlaskTest):
         self.oneview_client.server_profile_templates.get_all.return_value = \
             server_profile_template_list
 
-        self.oneview_client.connection.get\
-            .return_value = logical_encl_assoc
-        self.oneview_client.logical_enclosures.get\
-            .return_value = logical_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            logical_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             drive_enclosure
 
@@ -137,11 +129,6 @@ class TestComputerSystemCollection(BaseFlaskTest):
         self.oneview_client.\
             server_profile_templates.get_all.assert_called_with()
 
-        spt_with_storage_ctrler = server_profile_template_list[0]
-        self.oneview_client.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        self.oneview_client.logical_enclosures.get.assert_called_with(
-            logical_encl["uri"])
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
+        self.oneview_client.logical_enclosures.get_all.assert_called_with()
+        self.oneview_client.enclosures.get_all.assert_called_with()

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -76,15 +76,9 @@ class TestResourceBlock(BaseFlaskTest):
             self.server_profile_templates = json.load(f)
 
         with open(
-            'oneview_redfish_toolkit/mockups/oneview/'
-            'LogicalEnclByIndexAssociationWithEnclGroup.json'
+            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json'
         ) as f:
-            self.log_encl_index_assoc = json.load(f)
-
-        with open(
-            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosure.json'
-        ) as f:
-            self.log_encl = json.load(f)
+            self.log_encl_list = json.load(f)
 
         with open(
                 'oneview_redfish_toolkit/mockups/redfish'
@@ -131,12 +125,11 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.index_resources.get.return_value = self.drive
         self.oneview_client.connection.get.side_effect = [
             self.drive_index_tree,
-            self.log_encl_index_assoc
         ]
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
         self.oneview_client.\
-            logical_enclosures.get.return_value = self.log_encl
+            logical_enclosures.get_all.return_value = self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -156,10 +149,6 @@ class TestResourceBlock(BaseFlaskTest):
             [
                 call("/rest/index/trees/rest/drives/"
                      "c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e?parentDepth=3"),
-                call("/rest/index/associations/resources"
-                     "?parenturi=/rest/enclosure-groups/"
-                     "bc41f38d-e8ce-4241-acd1-00b2d8c5d0fa"
-                     "&category=logical-enclosures"),
             ])
         self.oneview_client.\
             server_profile_templates.get_all.assert_called_with()
@@ -184,11 +173,11 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.index_resources.get.return_value = drive_composed
         self.oneview_client.connection.get.side_effect = [
             self.drive_composed_index_tree,
-            self.log_encl_index_assoc
         ]
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -208,10 +197,6 @@ class TestResourceBlock(BaseFlaskTest):
             [
                 call("/rest/index/trees/rest/drives/"
                      "c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e?parentDepth=3"),
-                call("/rest/index/associations/resources"
-                     "?parenturi=/rest/enclosure-groups/"
-                     "bc41f38d-e8ce-4241-acd1-00b2d8c5d0fa"
-                     "&category=logical-enclosures"),
             ])
         self.oneview_client.\
             server_profile_templates.get_all.assert_called_with()
@@ -224,9 +209,8 @@ class TestResourceBlock(BaseFlaskTest):
             self.server_hardware
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -245,9 +229,8 @@ class TestResourceBlock(BaseFlaskTest):
         expected_rb = copy.deepcopy(self.expected_sh_resource_block)
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -286,9 +269,8 @@ class TestResourceBlock(BaseFlaskTest):
         expected_rb["Links"].pop("ComputerSystems")
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -327,9 +309,8 @@ class TestResourceBlock(BaseFlaskTest):
 
         self.oneview_client.server_profile_templates.get_all.return_value = \
             self.server_profile_templates
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -353,12 +334,6 @@ class TestResourceBlock(BaseFlaskTest):
 
         self.oneview_client.server_hardware.get.assert_called_with(
             self.server_hardware["uuid"])
-        self.oneview_client.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=/rest/enclosure-groups/"
-            "bc41f38d-e8ce-4241-acd1-00b2d8c5d0fa"
-            "&category=logical-enclosures"
-        )
 
         encl_group_uri = self.server_hardware["serverGroupUri"]
         sh_type_uri = self.server_hardware["serverHardwareTypeUri"]
@@ -382,9 +357,8 @@ class TestResourceBlock(BaseFlaskTest):
             self.resource_not_found
         self.oneview_client.server_profile_templates.get.return_value = \
             self.server_profile_template
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
         self.oneview_client.drive_enclosures.get_all.return_value = \
             self.drive_enclosure_list
 
@@ -413,9 +387,8 @@ class TestResourceBlock(BaseFlaskTest):
             self.resource_not_found
         self.oneview_client.server_profile_templates.get.return_value = \
             self.server_profile_templates[1]
-        self.oneview_client.connection.get.return_value = \
-            self.log_encl_index_assoc
-        self.oneview_client.logical_enclosures.get.return_value = self.log_encl
+        self.oneview_client.logical_enclosures.get_all.return_value = \
+            self.log_encl_list
 
         response = self.client.get(
             "/redfish/v1/CompositionService/ResourceBlocks"

--- a/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_resource_block.py
@@ -152,8 +152,7 @@ class TestResourceBlock(BaseFlaskTest):
             ])
         self.oneview_client.\
             server_profile_templates.get_all.assert_called_with()
-        self.oneview_client.logical_enclosures.get.assert_called_with(
-            self.log_encl["uri"])
+        self.oneview_client.logical_enclosures.get_all.assert_called_with()
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_storage_resource_block_when_drive_is_composed(self):
@@ -200,8 +199,7 @@ class TestResourceBlock(BaseFlaskTest):
             ])
         self.oneview_client.\
             server_profile_templates.get_all.assert_called_with()
-        self.oneview_client.logical_enclosures.get.assert_called_with(
-            self.log_encl["uri"])
+        self.oneview_client.logical_enclosures.get_all.assert_called_with()
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_server_hardware_resource_block(self):
@@ -342,8 +340,7 @@ class TestResourceBlock(BaseFlaskTest):
                 filter=["enclosureGroupUri='" + encl_group_uri + "'",
                         "serverHardwareTypeUri='" + sh_type_uri + "'"]
                 )
-        self.oneview_client.logical_enclosures.get.assert_called_with(
-            self.log_encl["uri"])
+        self.oneview_client.logical_enclosures.get_all.assert_called_with()
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_spt_resource_block(self):
@@ -372,8 +369,7 @@ class TestResourceBlock(BaseFlaskTest):
         self.assertEqual("application/json", response.mimetype)
         self.assertEqualMockup(expected_resource_block, result)
 
-        self.oneview_client.logical_enclosures.get.assert_called_with(
-            self.log_encl["uri"])
+        self.oneview_client.logical_enclosures.get_all.assert_called_with()
         self.oneview_client.drive_enclosures.get_all.assert_called_with()
 
     def test_get_spt_resource_when_template_has_not_valid_controller(self):

--- a/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
@@ -44,15 +44,9 @@ class TestZoneCollection(BaseFlaskTest):
             self.zone_collection_mockup = json.load(f)
 
         with open(
-            'oneview_redfish_toolkit/mockups/oneview/'
-            'LogicalEnclByIndexAssociationWithEnclGroup.json'
+            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json'
         ) as f:
-            self.logical_encl_assoc = json.load(f)
-
-        with open(
-            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosure.json'
-        ) as f:
-            self.logical_encl = json.load(f)
+            self.logical_encl_list = json.load(f)
 
         with open(
                 'oneview_redfish_toolkit/mockups/oneview'
@@ -87,8 +81,8 @@ class TestZoneCollection(BaseFlaskTest):
 
         ov_api = self.oneview_client
 
-        ov_api.connection.get.return_value = self.logical_encl_assoc
-        ov_api.logical_enclosures.get.return_value = self.logical_encl
+        ov_api.logical_enclosures.get_all.return_value = \
+            self.logical_encl_list
 
         ov_api.server_profile_templates.get_all.return_value = \
             self.server_profile_template_list
@@ -105,18 +99,9 @@ class TestZoneCollection(BaseFlaskTest):
 
         self.assertEqualMockup(self.zone_collection_mockup, result)
 
-        spt_with_storage_ctrler = self.server_profile_template_list[0]
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.logical_enclosures.get.assert_called_with(
-            self.logical_encl["uri"])
         ov_api.drive_enclosures.get_all.assert_called_with()
+        ov_api.logical_enclosures.get_all.assert_called_with()
+        ov_api.enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_empty(self):
         """Tests ZoneCollection with an empty list"""
@@ -140,8 +125,8 @@ class TestZoneCollection(BaseFlaskTest):
 
     def test_get_zone_collection_without_drive_enclosure_associated(self):
         ov_api = self.oneview_client
-        ov_api.connection.get.return_value = self.logical_encl_assoc
-        ov_api.logical_enclosures.get.return_value = self.logical_encl
+        ov_api.logical_enclosures.get_all.return_value = \
+            self.logical_encl_list
 
         zone_collection_mockup = copy.deepcopy(self.zone_collection_mockup)
         zone_collection_mockup["Members@odata.count"] = 1
@@ -160,24 +145,15 @@ class TestZoneCollection(BaseFlaskTest):
         self.assertEqual("application/json", response.mimetype)
         self.assertEqualMockup(zone_collection_mockup, result)
 
-        spt_with_storage_ctrler = self.server_profile_template_list[0]
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.logical_enclosures.get.assert_called_with(
-            self.logical_encl["uri"])
         ov_api.drive_enclosures.get_all.assert_called_with()
+        ov_api.logical_enclosures.get_all.assert_called_with()
+        ov_api.enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_with_drive_enclosure_without_drives(self):
         ov_api = self.oneview_client
 
-        ov_api.connection.get.return_value = self.logical_encl_assoc
-        ov_api.logical_enclosures.get.return_value = self.logical_encl
+        ov_api.logical_enclosures.get_all.return_value = \
+            self.logical_encl_list
 
         zone_collection_mockup = copy.deepcopy(self.zone_collection_mockup)
         zone_collection_mockup["Members@odata.count"] = 1
@@ -201,15 +177,6 @@ class TestZoneCollection(BaseFlaskTest):
 
         self.assertEqualMockup(zone_collection_mockup, result)
 
-        spt_with_storage_ctrler = self.server_profile_template_list[0]
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.connection.get.assert_called_with(
-            "/rest/index/associations/resources"
-            "?parenturi=" + spt_with_storage_ctrler["enclosureGroupUri"]
-            + "&category=logical-enclosures")
-        ov_api.logical_enclosures.get.assert_called_with(
-            self.logical_encl["uri"])
         ov_api.drive_enclosures.get_all.assert_called_with()
+        ov_api.logical_enclosures.get_all.assert_called_with()
+        ov_api.enclosures.get_all.assert_called_with()

--- a/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_zone_collection.py
@@ -101,7 +101,6 @@ class TestZoneCollection(BaseFlaskTest):
 
         ov_api.drive_enclosures.get_all.assert_called_with()
         ov_api.logical_enclosures.get_all.assert_called_with()
-        ov_api.enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_empty(self):
         """Tests ZoneCollection with an empty list"""
@@ -147,7 +146,6 @@ class TestZoneCollection(BaseFlaskTest):
 
         ov_api.drive_enclosures.get_all.assert_called_with()
         ov_api.logical_enclosures.get_all.assert_called_with()
-        ov_api.enclosures.get_all.assert_called_with()
 
     def test_get_zone_collection_with_drive_enclosure_without_drives(self):
         ov_api = self.oneview_client
@@ -179,4 +177,3 @@ class TestZoneCollection(BaseFlaskTest):
 
         ov_api.drive_enclosures.get_all.assert_called_with()
         ov_api.logical_enclosures.get_all.assert_called_with()
-        ov_api.enclosures.get_all.assert_called_with()


### PR DESCRIPTION
Closes partially #428

Previously the application did  **N²** requests to retrieve the enclosures URI with the same enclosureGroupURI from the ServerProfileTemplates related with the ResourceBlock.
Now the application just need **1** request to retrieve this data.
These requests is performed for the Resource Block GET request.

We have an average time from **1.70s** on previous version to **0.89s** on current version for ResourceBlock GET request.
And we have an average reduction of **6** OneView requests per Resource Block GET request.

Below there is a graph comparing previous and currently performance with the elapsed time to retrieve each one of all 111 Resource Blocks on the DCS that we have:
![graphperformance5](https://user-images.githubusercontent.com/20116439/45903515-5c04f780-bdc0-11e8-92f8-6dc69ef2d4ce.png)

This improvement also impacts on ResourceZoneCollection and ComputerSystemCollection.