### PR TITLE
Improvement performance for multiple OneViews

### DIFF
--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -148,10 +148,10 @@ def get_resource_block_ethernet_interface(uuid, id):
         server_profile_template = \
             g.oneview_client.server_profile_templates.get(uuid)
 
-        connSettings = server_profile_template["connectionSettings"]
+        conn_settings = server_profile_template["connectionSettings"]
         connection = None
 
-        for conn in connSettings["connections"]:
+        for conn in conn_settings["connections"]:
             if str(conn["id"]) == id:
                 connection = conn
                 break

--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -37,6 +37,7 @@ from oneview_redfish_toolkit.api.storage_resource_block \
 from oneview_redfish_toolkit.blueprints.util.response_builder \
     import ResponseBuilder
 from oneview_redfish_toolkit import category_resource
+from oneview_redfish_toolkit import multiple_oneview
 from oneview_redfish_toolkit.services.manager_service import \
     get_manager_uuid
 from oneview_redfish_toolkit.services.zone_service import ZoneService
@@ -56,6 +57,8 @@ def get_resource_block(uuid):
             JSON: Redfish json with ResourceBlock.
     """
     try:
+        multiple_oneview.set_single_oneview_context()
+
         zone_service = ZoneService(g.oneview_client)
         resource = _get_oneview_resource(uuid)
         category = resource["category"]
@@ -114,6 +117,7 @@ def get_resource_block_computer_system(uuid):
         Returns:
             JSON: Redfish json with ResourceBlock Computer System.
     """
+    multiple_oneview.set_single_oneview_context()
 
     server_hardware = g.oneview_client.server_hardware.get(uuid)
     manager_uuid = get_manager_uuid(uuid)
@@ -139,6 +143,7 @@ def get_resource_block_ethernet_interface(uuid, id):
         Returns:
             JSON: Redfish json with ResourceBlock.
     """
+    multiple_oneview.set_single_oneview_context()
 
     try:
         server_profile_template = \

--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -40,11 +40,13 @@ from oneview_redfish_toolkit import category_resource
 from oneview_redfish_toolkit.services.manager_service import \
     get_manager_uuid
 from oneview_redfish_toolkit.services.zone_service import ZoneService
+from oneview_redfish_toolkit.single_oneview_context import single_oneview
 
 resource_block = Blueprint("resource_block", __name__)
 
 
 @resource_block.route(ResourceBlock.BASE_URI + "/<uuid>", methods=["GET"])
+@single_oneview
 def get_resource_block(uuid):
     """Get the Redfish ResourceBlock for a given UUID.
 
@@ -104,6 +106,7 @@ def get_resource_block(uuid):
 
 @resource_block.route(
     ResourceBlock.BASE_URI + "/<uuid>/Systems/1", methods=["GET"])
+@single_oneview
 def get_resource_block_computer_system(uuid):
     """Get Computer System of a Resource Block
 
@@ -129,6 +132,7 @@ def get_resource_block_computer_system(uuid):
 @resource_block.route(
     ResourceBlock.BASE_URI + "/<uuid>/EthernetInterfaces/<id>",
     methods=["GET"])
+@single_oneview
 def get_resource_block_ethernet_interface(uuid, id):
     """Get the Redfish ResourceBlock of type Network for the given UUID and ID.
 

--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -37,7 +37,6 @@ from oneview_redfish_toolkit.api.storage_resource_block \
 from oneview_redfish_toolkit.blueprints.util.response_builder \
     import ResponseBuilder
 from oneview_redfish_toolkit import category_resource
-from oneview_redfish_toolkit import multiple_oneview
 from oneview_redfish_toolkit.services.manager_service import \
     get_manager_uuid
 from oneview_redfish_toolkit.services.zone_service import ZoneService
@@ -57,8 +56,6 @@ def get_resource_block(uuid):
             JSON: Redfish json with ResourceBlock.
     """
     try:
-        multiple_oneview.set_single_oneview_context()
-
         zone_service = ZoneService(g.oneview_client)
         resource = _get_oneview_resource(uuid)
         category = resource["category"]
@@ -117,7 +114,6 @@ def get_resource_block_computer_system(uuid):
         Returns:
             JSON: Redfish json with ResourceBlock Computer System.
     """
-    multiple_oneview.set_single_oneview_context()
 
     server_hardware = g.oneview_client.server_hardware.get(uuid)
     manager_uuid = get_manager_uuid(uuid)
@@ -143,7 +139,6 @@ def get_resource_block_ethernet_interface(uuid, id):
         Returns:
             JSON: Redfish json with ResourceBlock.
     """
-    multiple_oneview.set_single_oneview_context()
 
     try:
         server_profile_template = \

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -102,8 +102,9 @@ def query_ov_client_by_resource(resource_id, resource, function,
     resp = execute_query_ov_client(ov_client, resource, function,
                                    *args, **kwargs)
 
-    # If retrieve resource using SingleOneViewIp and the resource is not
-    # mapped yet, then map the resource for the OneView IP
+    # If it's on Single OneView Context and the resource is not
+    # mapped to an OneView IP, then we update cache in advance for 
+    # future requests for this resource
     if single_oneview_ip and not cached_oneview_ip:
         set_map_resources_entry(resource_id, single_oneview_ip)
 

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -219,8 +219,6 @@ def execute_query_ov_client(ov_client, resource, function, *args, **kwargs):
         try:
             result = ov_function(*args, **kwargs)
             return result
-        except Exception as exception:
-            raise exception
         finally:
             elapsed_time = time.time() - start_time
 

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -79,7 +79,7 @@ def query_ov_client_by_resource(resource_id, resource, function,
             dict: OneView resource
     """
     # Get OneView's IP in the single OneView context or cached by resource ID
-    ip_oneview = _get_single_oneview_ip() and \
+    ip_oneview = _get_single_oneview_ip() or \
         get_ov_ip_by_resource(resource_id)
 
     # If resource is not cached yet search in all OneViews

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -35,6 +35,9 @@ from oneview_redfish_toolkit import single_oneview_context as single
 #   globals()['map_resources_ov']
 
 
+lock = threading.Lock()
+
+
 def init_map_resources():
     """Initialize cached resources map"""
     globals()['map_resources_ov'] = OrderedDict()
@@ -57,7 +60,6 @@ def get_map_appliances():
 
 def set_map_resources_entry(resource_id, ip_oneview):
     """Set new cached resource"""
-    lock = threading.Lock()
     with lock:
         get_map_resources()[resource_id] = ip_oneview
 

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -103,7 +103,7 @@ def query_ov_client_by_resource(resource_id, resource, function,
                                    *args, **kwargs)
 
     # If it's on Single OneView Context and the resource is not
-    # mapped to an OneView IP, then we update cache in advance for 
+    # mapped to an OneView IP, then we update cache in advance for
     # future requests for this resource
     if single_oneview_ip and not cached_oneview_ip:
         set_map_resources_entry(resource_id, single_oneview_ip)

--- a/oneview_redfish_toolkit/single_oneview_context.py
+++ b/oneview_redfish_toolkit/single_oneview_context.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Python libs
+import logging
+import threading
+
+# 3rd party libs
+from flask import g
+
+# Modules own libs
+from oneview_redfish_toolkit.config import PERFORMANCE_LOGGER_NAME
+
+
+def single_oneview(original_func):
+    """Python decorator for endpoints with single OneView context"""
+    def new_function(*args, **kwargs):
+        """Function to set single OneView context"""
+        logging.getLogger(PERFORMANCE_LOGGER_NAME).debug(
+            "Thread {} in Single OneView Context".
+            format(threading.get_ident()))
+        set_single_oneview_context()
+        return original_func(*args, **kwargs)
+
+    new_function.__name__ = original_func.__name__
+    return new_function
+
+
+def set_single_oneview_context():
+    """Set to use the same OneView IP in the same request"""
+    g.single_oneview_context = True
+
+
+def is_single_oneview_context():
+    """Check if it ot be used the same OneView IP on the request context"""
+    return 'single_oneview_context' in g
+
+
+def get_single_oneview_ip():
+    """Get the same OneView's IP in request context"""
+    if 'single_oneview_ip' in g:
+        return g.single_oneview_ip
+    return None
+
+
+def set_single_oneview_ip(oneview_ip):
+    """Set OneView's IP to be used in the same request context"""
+    if not get_single_oneview_ip():
+        g.single_oneview_ip = oneview_ip

--- a/oneview_redfish_toolkit/tests/test_multiple_oneview.py
+++ b/oneview_redfish_toolkit/tests/test_multiple_oneview.py
@@ -34,13 +34,14 @@ from oneview_redfish_toolkit import config
 from oneview_redfish_toolkit import connection
 from oneview_redfish_toolkit import handler_multiple_oneview
 from oneview_redfish_toolkit import multiple_oneview
+from oneview_redfish_toolkit import single_oneview_context
 
 
 @mock.patch.object(config, 'get_config')
 @mock.patch.object(client_session, 'request')
 @mock.patch.object(connection, 'OneViewClient')
 @mock.patch.object(client_session, 'get_oneview_client')
-@mock.patch.object(multiple_oneview, 'g')
+@mock.patch.object(single_oneview_context, 'g')
 class TestMultipleOneView(unittest.TestCase):
     """Test class for multiple_oneview"""
 

--- a/oneview_redfish_toolkit/tests/test_multiple_oneview.py
+++ b/oneview_redfish_toolkit/tests/test_multiple_oneview.py
@@ -40,6 +40,7 @@ from oneview_redfish_toolkit import multiple_oneview
 @mock.patch.object(client_session, 'request')
 @mock.patch.object(connection, 'OneViewClient')
 @mock.patch.object(client_session, 'get_oneview_client')
+@mock.patch.object(multiple_oneview, 'g')
 class TestMultipleOneView(unittest.TestCase):
     """Test class for multiple_oneview"""
 
@@ -77,7 +78,8 @@ class TestMultipleOneView(unittest.TestCase):
         self.config_obj.add_section('oneview_config')
         self.config_obj.add_section('redfish')
 
-    def test_search_in_all_ov_found_on_second(self, get_oneview_client,
+    def test_search_in_all_ov_found_on_second(self, req_context,
+                                              get_oneview_client,
                                               oneview_client_mockup,
                                               request,
                                               get_config):
@@ -126,6 +128,7 @@ class TestMultipleOneView(unittest.TestCase):
         )
 
     def test_search_in_all_ov_when_auth_mode_is_conf(self,
+                                                     req_context,
                                                      get_oneview_client,
                                                      oneview_client_mockup,
                                                      request,
@@ -169,7 +172,8 @@ class TestMultipleOneView(unittest.TestCase):
              call("oneview.com")]
         )
 
-    def test_search_mapped_after_search_in_all(self, get_oneview_client,
+    def test_search_mapped_after_search_in_all(self, req_context,
+                                               get_oneview_client,
                                                oneview_client_mockup,
                                                request,
                                                get_config):

--- a/oneview_redfish_toolkit/tests/test_single_oneview_context.py
+++ b/oneview_redfish_toolkit/tests/test_single_oneview_context.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (2018) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Python libs
+import json
+from unittest import mock
+
+# 3rd party libs
+from unittest.mock import call
+
+from flask_api import status
+from hpOneView.exceptions import HPOneViewException
+
+# Module libs
+from oneview_redfish_toolkit.blueprints import resource_block
+from oneview_redfish_toolkit import category_resource
+from oneview_redfish_toolkit import config
+from oneview_redfish_toolkit import multiple_oneview
+from oneview_redfish_toolkit import single_oneview_context
+from oneview_redfish_toolkit.tests.base_flask_test import BaseFlaskTest
+
+
+class TestResourceBlock(BaseFlaskTest):
+    """Tests for ResourceBlock blueprint"""
+
+    @classmethod
+    def setUpClass(self):
+        super(TestResourceBlock, self).setUpClass()
+
+        self.app.register_blueprint(resource_block.resource_block)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/ServerHardware.json'
+        ) as f:
+            self.server_hardware = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview'
+            '/ServerProfileTemplate.json'
+        ) as f:
+            self.server_profile_template = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/Drive.json'
+        ) as f:
+            self.drive = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/DriveIndexTrees.json'
+        ) as f:
+            self.drive_index_tree = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/'
+            'DriveComposedIndexTrees.json'
+        ) as f:
+            self.drive_composed_index_tree = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview'
+            '/ServerProfileTemplates.json'
+        ) as f:
+            self.server_profile_templates = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/oneview/LogicalEnclosures.json'
+        ) as f:
+            self.log_encl_list = json.load(f)
+
+        with open(
+                'oneview_redfish_toolkit/mockups/redfish'
+                '/ServerHardwareResourceBlock.json'
+        ) as f:
+            self.expected_sh_resource_block = json.load(f)
+
+        with open(
+                'oneview_redfish_toolkit/mockups/oneview'
+                '/DriveEnclosureList.json'
+        ) as f:
+            self.drive_enclosure_list = json.load(f)
+
+        self.resource_not_found = HPOneViewException({
+            "errorCode": "RESOURCE_NOT_FOUND",
+            "message": "Any resource not found message"
+        })
+
+    @mock.patch.object(config, 'get_oneview_multiple_ips')
+    def test_get_storage_resource_block_single_ov(self,
+                                                  get_oneview_multiple_ips):
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json'
+        ) as f:
+            expected_resource_block = json.load(f)
+
+        multiple_oneview.init_map_resources()
+        category_resource.init_map_category_resources()
+
+        list_ips = ['10.0.0.1', '10.0.0.2', '10.0.0.3']
+        get_oneview_multiple_ips.return_value = list_ips
+
+        self.oneview_client.server_hardware.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.resource_not_found,
+            ]
+        self.oneview_client.server_profile_templates.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.resource_not_found,
+            ]
+        self.oneview_client.index_resources.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.drive,
+            ]
+        self.oneview_client.connection.get.return_value = self.drive_index_tree
+        self.oneview_client.server_profile_templates.get_all.return_value = \
+            self.server_profile_templates
+        self.oneview_client.\
+            logical_enclosures.get_all.return_value = self.log_encl_list
+        self.oneview_client.drive_enclosures.get_all.return_value = \
+            self.drive_enclosure_list
+
+        uri = "/redfish/v1/CompositionService/ResourceBlocks"\
+            "/c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e"
+        uuid = uri.split('/')[-1]
+        response = self.client.get(uri)
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqualMockup(expected_resource_block, result)
+
+        self.oneview_client.server_hardware.get.assert_has_calls([
+            call(uuid),
+            call(uuid),
+            call(uuid)
+            ])
+        self.oneview_client.server_profile_templates.get.assert_has_calls([
+            call(uuid),
+            call(uuid),
+            call(uuid)
+            ])
+        self.oneview_client.index_resources.get.assert_has_calls([
+            call(self.drive["uri"]),
+            call(self.drive["uri"]),
+            call(self.drive["uri"]),
+            ])
+        conn_uri = "/rest/index/trees/rest/drives/"\
+            "c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e?parentDepth=3"
+        # Check for single calls on OneView context
+        self.oneview_client.connection.get.assert_called_once_with(
+            conn_uri)
+        self.oneview_client.\
+            server_profile_templates.get_all.assert_called_once_with()
+        self.oneview_client.logical_enclosures.get_all.\
+            assert_called_once_with()
+        self.oneview_client.drive_enclosures.get_all.\
+            assert_called_once_with()
+
+    @mock.patch.object(config, 'get_oneview_multiple_ips')
+    @mock.patch.object(single_oneview_context, 'is_single_oneview_context')
+    def test_get_storage_resource_block_without_single_ov(self,
+                                                          is_single_ov_context,
+                                                          get_ov_multiple_ips):
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json'
+        ) as f:
+            expected_resource_block = json.load(f)
+
+        multiple_oneview.init_map_resources()
+        category_resource.init_map_category_resources()
+
+        list_ips = ['10.0.0.1', '10.0.0.2', '10.0.0.3']
+        get_ov_multiple_ips.return_value = list_ips
+
+        is_single_ov_context.return_value = False
+
+        self.oneview_client.server_hardware.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.resource_not_found,
+            ]
+        self.oneview_client.server_profile_templates.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.resource_not_found,
+            ]
+        self.oneview_client.index_resources.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.drive,
+            ]
+        self.oneview_client.connection.get.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.drive_index_tree
+            ]
+        self.oneview_client.server_profile_templates.get_all.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.server_profile_templates
+            ]
+        self.oneview_client.logical_enclosures.get_all.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.log_encl_list
+            ]
+        self.oneview_client.drive_enclosures.get_all.side_effect = [
+            self.resource_not_found,
+            self.resource_not_found,
+            self.drive_enclosure_list
+            ]
+
+        uri = "/redfish/v1/CompositionService/ResourceBlocks"\
+            "/c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e"
+        uuid = uri.split('/')[-1]
+        response = self.client.get(uri)
+
+        result = json.loads(response.data.decode("utf-8"))
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual("application/json", response.mimetype)
+        self.assertEqualMockup(expected_resource_block, result)
+
+        self.oneview_client.server_hardware.get.assert_has_calls([
+            call(uuid),
+            call(uuid),
+            call(uuid)
+            ])
+        self.oneview_client.server_profile_templates.get.assert_has_calls([
+            call(uuid),
+            call(uuid),
+            call(uuid)
+            ])
+        self.oneview_client.index_resources.get.assert_has_calls([
+            call(self.drive["uri"]),
+            call(self.drive["uri"]),
+            call(self.drive["uri"]),
+            ])
+        conn_uri = "/rest/index/trees/rest/drives/"\
+            "c4f0392d-fae9-4c2e-a2e6-b22e6bb7533e?parentDepth=3"
+        # Check for multiple calls on multiple OneView context
+        self.oneview_client.connection.get.assert_has_calls(
+            [call(conn_uri), call(conn_uri), call(conn_uri)])
+        self.oneview_client.server_profile_templates.get_all.has_calls(
+            [call(), call(), call()])
+        self.oneview_client.logical_enclosures.get_all.has_calls(
+            [call(), call(), call()])
+        self.oneview_client.drive_enclosures.get_all.has_calls(
+            [call(), call(), call()])

--- a/oneview_redfish_toolkit/tests/test_single_oneview_context.py
+++ b/oneview_redfish_toolkit/tests/test_single_oneview_context.py
@@ -43,17 +43,6 @@ class TestResourceBlock(BaseFlaskTest):
         self.app.register_blueprint(resource_block.resource_block)
 
         with open(
-            'oneview_redfish_toolkit/mockups/oneview/ServerHardware.json'
-        ) as f:
-            self.server_hardware = json.load(f)
-
-        with open(
-            'oneview_redfish_toolkit/mockups/oneview'
-            '/ServerProfileTemplate.json'
-        ) as f:
-            self.server_profile_template = json.load(f)
-
-        with open(
             'oneview_redfish_toolkit/mockups/oneview/Drive.json'
         ) as f:
             self.drive = json.load(f)
@@ -62,12 +51,6 @@ class TestResourceBlock(BaseFlaskTest):
             'oneview_redfish_toolkit/mockups/oneview/DriveIndexTrees.json'
         ) as f:
             self.drive_index_tree = json.load(f)
-
-        with open(
-            'oneview_redfish_toolkit/mockups/oneview/'
-            'DriveComposedIndexTrees.json'
-        ) as f:
-            self.drive_composed_index_tree = json.load(f)
 
         with open(
             'oneview_redfish_toolkit/mockups/oneview'
@@ -81,16 +64,15 @@ class TestResourceBlock(BaseFlaskTest):
             self.log_encl_list = json.load(f)
 
         with open(
-                'oneview_redfish_toolkit/mockups/redfish'
-                '/ServerHardwareResourceBlock.json'
-        ) as f:
-            self.expected_sh_resource_block = json.load(f)
-
-        with open(
                 'oneview_redfish_toolkit/mockups/oneview'
                 '/DriveEnclosureList.json'
         ) as f:
             self.drive_enclosure_list = json.load(f)
+
+        with open(
+            'oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json'
+        ) as f:
+            self.expected_resource_block = json.load(f)
 
         self.resource_not_found = HPOneViewException({
             "errorCode": "RESOURCE_NOT_FOUND",
@@ -100,11 +82,6 @@ class TestResourceBlock(BaseFlaskTest):
     @mock.patch.object(config, 'get_oneview_multiple_ips')
     def test_get_storage_resource_block_single_ov(self,
                                                   get_oneview_multiple_ips):
-        with open(
-            'oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json'
-        ) as f:
-            expected_resource_block = json.load(f)
-
         multiple_oneview.init_map_resources()
         category_resource.init_map_category_resources()
 
@@ -143,7 +120,7 @@ class TestResourceBlock(BaseFlaskTest):
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
-        self.assertEqualMockup(expected_resource_block, result)
+        self.assertEqualMockup(self.expected_resource_block, result)
 
         self.oneview_client.server_hardware.get.assert_has_calls([
             call(uuid),
@@ -172,16 +149,19 @@ class TestResourceBlock(BaseFlaskTest):
         self.oneview_client.drive_enclosures.get_all.\
             assert_called_once_with()
 
+        ov_ip_cached_drive = multiple_oneview.get_ov_ip_by_resource(
+            self.drive['uri'])
+        self.assertEqual(ov_ip_cached_drive, list_ips[2])
+
+        ov_ip_cached_conn_drive = multiple_oneview.get_ov_ip_by_resource(
+            conn_uri)
+        self.assertTrue(ov_ip_cached_conn_drive, list_ips[2])
+
     @mock.patch.object(config, 'get_oneview_multiple_ips')
     @mock.patch.object(single_oneview_context, 'is_single_oneview_context')
     def test_get_storage_resource_block_without_single_ov(self,
                                                           is_single_ov_context,
                                                           get_ov_multiple_ips):
-        with open(
-            'oneview_redfish_toolkit/mockups/redfish/StorageResourceBlock.json'
-        ) as f:
-            expected_resource_block = json.load(f)
-
         multiple_oneview.init_map_resources()
         category_resource.init_map_category_resources()
 
@@ -235,7 +215,7 @@ class TestResourceBlock(BaseFlaskTest):
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual("application/json", response.mimetype)
-        self.assertEqualMockup(expected_resource_block, result)
+        self.assertEqualMockup(self.expected_resource_block, result)
 
         self.oneview_client.server_hardware.get.assert_has_calls([
             call(uuid),
@@ -263,3 +243,11 @@ class TestResourceBlock(BaseFlaskTest):
             [call(), call(), call()])
         self.oneview_client.drive_enclosures.get_all.has_calls(
             [call(), call(), call()])
+
+        ov_ip_cached_drive = multiple_oneview.get_ov_ip_by_resource(
+            self.drive['uri'])
+        self.assertEqual(ov_ip_cached_drive, list_ips[2])
+
+        ov_ip_cached_conn_drive = multiple_oneview.get_ov_ip_by_resource(
+            conn_uri)
+        self.assertTrue(ov_ip_cached_conn_drive, list_ips[2])

--- a/oneview_redfish_toolkit/tests/test_single_oneview_context.py
+++ b/oneview_redfish_toolkit/tests/test_single_oneview_context.py
@@ -33,12 +33,12 @@ from oneview_redfish_toolkit import single_oneview_context
 from oneview_redfish_toolkit.tests.base_flask_test import BaseFlaskTest
 
 
-class TestResourceBlock(BaseFlaskTest):
+class TestSingleOneViewContext(BaseFlaskTest):
     """Tests for ResourceBlock blueprint"""
 
     @classmethod
     def setUpClass(self):
-        super(TestResourceBlock, self).setUpClass()
+        super(TestSingleOneViewContext, self).setUpClass()
 
         self.app.register_blueprint(resource_block.resource_block)
 


### PR DESCRIPTION
Closes #464 
Implementing Single OneView Context.
With this implementation the solution does not have to search in all OneViews after get the OneView that it's working with inside the same request context. Before this implementation every "get_all()" call to retrieve OneView data was requested on each one of multiple OneViews. With this implementation, after the application find any resource on one of multiple OneViews, all the subsequent calls will be requested only on that same OneView.

On the graph below there is the comparison before and after this implementation, for an Storage ResourceBlock request on toolkit API using three mulitple OneViews, reducing from **21** OneView requests needed to **13** requests, and elapsed time from **2.18** seconds to **0.88** seconds:

![singleoneviewcontext](https://user-images.githubusercontent.com/20116439/46474927-7eccde00-c7ba-11e8-965c-7991b953a1b3.png)
