### PR TITLE
Include OneviewRedfishError handle on flask

### DIFF
--- a/oneview_redfish_toolkit/api/computer_system.py
+++ b/oneview_redfish_toolkit/api/computer_system.py
@@ -16,8 +16,9 @@
 
 import collections
 from copy import deepcopy
+from flask_api import status
+from werkzeug.exceptions import abort
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 from oneview_redfish_toolkit.api.resource_block_collection import \
@@ -218,9 +219,9 @@ class ComputerSystem(RedfishJsonValidator):
             server_profile_template)
 
         if storage_blocks and not controller:
-            raise OneViewRedfishError(
-                "The Server Profile Template should have a valid "
-                "storage controller to use the Storage Resource Blocks passed")
+            abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
+                  "The Server Profile Template should have a valid "
+                  "storage controller to use the Storage Resource Blocks passed")
 
         for index, storage_block in enumerate(storage_blocks):
             storage_id = index + 1

--- a/oneview_redfish_toolkit/api/computer_system.py
+++ b/oneview_redfish_toolkit/api/computer_system.py
@@ -16,9 +16,9 @@
 
 import collections
 from copy import deepcopy
-from flask_api import status
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidConditionException
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 from oneview_redfish_toolkit.api.resource_block_collection import \
@@ -219,10 +219,9 @@ class ComputerSystem(RedfishJsonValidator):
             server_profile_template)
 
         if storage_blocks and not controller:
-            raise OneViewRedfishException(
+            raise OneViewRedfishInvalidConditionException(
                 "The Server Profile Template should have a valid storage "
-                "controller to use the Storage Resource Blocks passed",
-                status.HTTP_403_FORBIDDEN
+                "controller to use the Storage Resource Blocks passed"
             )
 
         for index, storage_block in enumerate(storage_blocks):

--- a/oneview_redfish_toolkit/api/computer_system.py
+++ b/oneview_redfish_toolkit/api/computer_system.py
@@ -17,8 +17,8 @@
 import collections
 from copy import deepcopy
 from flask_api import status
-from werkzeug.exceptions import abort
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 from oneview_redfish_toolkit.api.resource_block_collection import \
@@ -219,9 +219,11 @@ class ComputerSystem(RedfishJsonValidator):
             server_profile_template)
 
         if storage_blocks and not controller:
-            abort(status.HTTP_403_FORBIDDEN,
-                  "The Server Profile Template should have a valid storage "
-                  "controller to use the Storage Resource Blocks passed")
+            raise OneViewRedfishException(
+                "The Server Profile Template should have a valid storage "
+                "controller to use the Storage Resource Blocks passed",
+                status.HTTP_403_FORBIDDEN
+            )
 
         for index, storage_block in enumerate(storage_blocks):
             storage_id = index + 1

--- a/oneview_redfish_toolkit/api/errors.py
+++ b/oneview_redfish_toolkit/api/errors.py
@@ -15,6 +15,8 @@
 # under the License.
 
 
+from flask_api import status
+
 NOT_FOUND_ONEVIEW_ERRORS = ['RESOURCE_NOT_FOUND', 'ProfileNotFoundException',
                             'DFRM_SAS_LOGICAL_JBOD_NOT_FOUND']
 
@@ -26,6 +28,26 @@ AUTH_ONEVIEW_ERRORS = ['AUTHN_AUTH_FAIL',
 
 class OneViewRedfishException(Exception):
 
-    def __init__(self, msg, status_code_error):
+    def __init__(self, msg):
         self.msg = msg
-        self.status_code_error = status_code_error
+
+
+class OneViewRedfishInvalidAttributeValueException(OneViewRedfishException):
+
+    def __init__(self, msg):
+        self.msg = msg
+        self.status_code_error = status.HTTP_400_BAD_REQUEST
+
+
+class OneViewRedfishInvalidConditionException(OneViewRedfishException):
+
+    def __init__(self, msg):
+        self.msg = msg
+        self.status_code_error = status.HTTP_403_FORBIDDEN
+
+
+class OneViewRedfishResourceNotFoundException(OneViewRedfishException):
+
+    def __init__(self, msg):
+        self.msg = msg
+        self.status_code_error = status.HTTP_404_NOT_FOUND

--- a/oneview_redfish_toolkit/api/errors.py
+++ b/oneview_redfish_toolkit/api/errors.py
@@ -22,3 +22,10 @@ AUTH_ONEVIEW_ERRORS = ['AUTHN_AUTH_FAIL',
                        'AUTHN_AUTH_FAIL_LOGINDOMAINNOTFOUND',
                        'AUTHORIZATION',
                        'Session.INVALID']
+
+
+class OneViewRedfishException(Exception):
+
+    def __init__(self, msg, status_code_error):
+        self.msg = msg
+        self.status_code_error = status_code_error

--- a/oneview_redfish_toolkit/api/network_device_function.py
+++ b/oneview_redfish_toolkit/api/network_device_function.py
@@ -15,8 +15,8 @@
 # under the License.
 
 from flask_api import status
-from werkzeug.exceptions import abort
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 
@@ -59,9 +59,11 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             virtual_port = self.get_resource_by_id(
                 port["virtualPorts"], "portNumber", virtual_port_number)
         except Exception:
-            abort(status.HTTP_404_NOT_FOUND,
-                  "NetworkDeviceFunction id {} not found.".format(
-                      device_function_id))
+            raise OneViewRedfishException(
+                "NetworkDeviceFunction id {} not found.".format(
+                    device_function_id),
+                status.HTTP_404_NOT_FOUND
+            )
 
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = device_function_id
@@ -74,10 +76,14 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             self.redfish["Ethernet"]["MACAddress"] = virtual_port["mac"]
             self.redfish["NetDevFuncType"] = "Ethernet"
         elif port["type"] == "FibreChannel":
-            abort(status.HTTP_501_NOT_IMPLEMENTED,
-                  "FibreChannel not implemented")
+            raise OneViewRedfishException(
+                "FibreChannel not implemented",
+                status.HTTP_501_NOT_IMPLEMENTED
+            )
         else:
-            abort(status.HTTP_400_BAD_REQUEST, "Type not supported")
+            raise OneViewRedfishException(
+                "Type not supported", status.HTTP_400_BAD_REQUEST
+            )
 
         self.redfish["@odata.context"] = \
             "/redfish/v1/$metadata#NetworkDeviceFunction.NetworkDeviceFunction"

--- a/oneview_redfish_toolkit/api/network_device_function.py
+++ b/oneview_redfish_toolkit/api/network_device_function.py
@@ -14,11 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from flask_api import status
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
-from oneview_redfish_toolkit.api.redfish_json_validator \
-    import RedfishJsonValidator
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
+from oneview_redfish_toolkit.api.redfish_json_validator import \
+    RedfishJsonValidator
 
 
 class NetworkDeviceFunction(RedfishJsonValidator):
@@ -59,10 +61,9 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             virtual_port = self.get_resource_by_id(
                 port["virtualPorts"], "portNumber", virtual_port_number)
         except Exception:
-            raise OneViewRedfishException(
+            raise OneViewRedfishResourceNotFoundException(
                 "NetworkDeviceFunction id {} not found.".format(
-                    device_function_id),
-                status.HTTP_404_NOT_FOUND
+                    device_function_id)
             )
 
         self.redfish["@odata.type"] = self.get_odata_type()
@@ -76,13 +77,12 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             self.redfish["Ethernet"]["MACAddress"] = virtual_port["mac"]
             self.redfish["NetDevFuncType"] = "Ethernet"
         elif port["type"] == "FibreChannel":
-            raise OneViewRedfishException(
-                "FibreChannel not implemented",
-                status.HTTP_501_NOT_IMPLEMENTED
+            raise OneViewRedfishInvalidAttributeValueException(
+                "FibreChannel not implemented"
             )
         else:
-            raise OneViewRedfishException(
-                "Type not supported", status.HTTP_400_BAD_REQUEST
+            raise OneViewRedfishInvalidAttributeValueException(
+                "Type not supported"
             )
 
         self.redfish["@odata.context"] = \

--- a/oneview_redfish_toolkit/api/network_device_function.py
+++ b/oneview_redfish_toolkit/api/network_device_function.py
@@ -14,9 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishResourceNotFoundError
+from flask_api import status
+from werkzeug.exceptions import abort
+
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 
@@ -59,8 +59,9 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             virtual_port = self.get_resource_by_id(
                 port["virtualPorts"], "portNumber", virtual_port_number)
         except Exception:
-            raise OneViewRedfishResourceNotFoundError(
-                device_function_id, "NetworkDeviceFunction")
+            abort(status.HTTP_404_NOT_FOUND,
+                  "NetworkDeviceFunction id {} not found.".format(
+                      device_function_id))
 
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = device_function_id
@@ -73,9 +74,9 @@ class NetworkDeviceFunction(RedfishJsonValidator):
             self.redfish["Ethernet"]["MACAddress"] = virtual_port["mac"]
             self.redfish["NetDevFuncType"] = "Ethernet"
         elif port["type"] == "FibreChannel":
-            raise OneViewRedfishError("FibreChannel not implemented")
+            abort(status.HTTP_501_NOT_IMPLEMENTED, "FibreChannel not implemented")
         else:
-            raise OneViewRedfishError("Type not supported")
+            abort(status.HTTP_400_BAD_REQUEST, "Type not supported")
 
         self.redfish["@odata.context"] = \
             "/redfish/v1/$metadata#NetworkDeviceFunction.NetworkDeviceFunction"

--- a/oneview_redfish_toolkit/api/network_port.py
+++ b/oneview_redfish_toolkit/api/network_port.py
@@ -14,7 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
+from flask_api import status
+from werkzeug.exceptions import abort
+
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 
@@ -48,7 +50,8 @@ class NetworkPort(RedfishJsonValidator):
         port = self.get_resource_by_id(physical_ports, "portNumber", port_id)
 
         if port["type"] not in ["Ethernet", "FibreChannel", "InfiniBand"]:
-            raise OneViewRedfishError("Port ID refers to invalid port type.")
+            abort(status.HTTP_400_BAD_REQUEST,
+                  "Port ID refers to an invalid port type.")
 
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = port_id
@@ -61,7 +64,7 @@ class NetworkPort(RedfishJsonValidator):
         elif port["type"] == "FibreChannel":
             self.redfish["AssociatedNetworkAddresses"].append(port["wwn"])
         else:
-            raise OneViewRedfishError("Type not supported")
+            abort(status.HTTP_400_BAD_REQUEST, "Type not supported")
 
         self.redfish["@odata.context"] = \
             "/redfish/v1/$metadata#NetworkPort.NetworkPort"

--- a/oneview_redfish_toolkit/api/network_port.py
+++ b/oneview_redfish_toolkit/api/network_port.py
@@ -14,9 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from flask_api import status
-
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 
@@ -49,12 +48,6 @@ class NetworkPort(RedfishJsonValidator):
 
         port = self.get_resource_by_id(physical_ports, "portNumber", port_id)
 
-        if port["type"] not in ["Ethernet", "FibreChannel", "InfiniBand"]:
-            raise OneViewRedfishException(
-                "Port ID refers to an invalid port type.",
-                status.HTTP_400_BAD_REQUEST
-            )
-
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = port_id
         self.redfish["Name"] = "Physical port {}".format(port_id)
@@ -66,9 +59,8 @@ class NetworkPort(RedfishJsonValidator):
         elif port["type"] == "FibreChannel":
             self.redfish["AssociatedNetworkAddresses"].append(port["wwn"])
         else:
-            raise OneViewRedfishException(
-                "Type not supported",
-                status.HTTP_400_BAD_REQUEST
+            raise OneViewRedfishInvalidAttributeValueException(
+                "Type not supported"
             )
 
         self.redfish["@odata.context"] = \

--- a/oneview_redfish_toolkit/api/network_port.py
+++ b/oneview_redfish_toolkit/api/network_port.py
@@ -15,8 +15,8 @@
 # under the License.
 
 from flask_api import status
-from werkzeug.exceptions import abort
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 
@@ -50,8 +50,10 @@ class NetworkPort(RedfishJsonValidator):
         port = self.get_resource_by_id(physical_ports, "portNumber", port_id)
 
         if port["type"] not in ["Ethernet", "FibreChannel", "InfiniBand"]:
-            abort(status.HTTP_400_BAD_REQUEST,
-                  "Port ID refers to an invalid port type.")
+            raise OneViewRedfishException(
+                "Port ID refers to an invalid port type.",
+                status.HTTP_400_BAD_REQUEST
+            )
 
         self.redfish["@odata.type"] = self.get_odata_type()
         self.redfish["Id"] = port_id
@@ -64,7 +66,10 @@ class NetworkPort(RedfishJsonValidator):
         elif port["type"] == "FibreChannel":
             self.redfish["AssociatedNetworkAddresses"].append(port["wwn"])
         else:
-            abort(status.HTTP_400_BAD_REQUEST, "Type not supported")
+            raise OneViewRedfishException(
+                "Type not supported",
+                status.HTTP_400_BAD_REQUEST
+            )
 
         self.redfish["@odata.context"] = \
             "/redfish/v1/$metadata#NetworkPort.NetworkPort"

--- a/oneview_redfish_toolkit/api/redfish_error.py
+++ b/oneview_redfish_toolkit/api/redfish_error.py
@@ -15,10 +15,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import collections
-from flask_api import status
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+import collections
+
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api.redfish_json_validator import \
     RedfishJsonValidator
 from oneview_redfish_toolkit import config
@@ -44,9 +47,8 @@ class RedfishError(RedfishJsonValidator):
         self.redfish["error"] = collections.OrderedDict()
         # Check if Code is a valid Code Error in the registry
         if code not in config.get_registry_dict()["Base"]["Messages"]:
-            raise OneViewRedfishException(
-                "Registry {} not found.".format(code),
-                status.HTTP_404_NOT_FOUND
+            raise OneViewRedfishResourceNotFoundException(
+                "Registry {} not found.".format(code)
             )
 
         self.redfish["error"]["code"] = "Base.1.1." + code
@@ -79,9 +81,8 @@ class RedfishError(RedfishJsonValidator):
         try:
             severity = messages[message_id]["Severity"]
         except Exception:
-            raise OneViewRedfishException(
-                "Message id {} not found.".format(message_id),
-                status.HTTP_404_NOT_FOUND
+            raise OneViewRedfishResourceNotFoundException(
+                "Message id {} not found.".format(message_id)
             )
 
         message = messages[message_id]["Message"]
@@ -92,9 +93,7 @@ class RedfishError(RedfishJsonValidator):
         if replaces != replacements:
             raise OneViewRedfishException(
                 'Message has {} replacements to be made but {} args '
-                'where sent'.format(replaces, replacements),
-                status.HTTP_500_INTERNAL_SERVER_ERROR
-
+                'where sent'.format(replaces, replacements)
             )
 
         # Replacing the marks in the message. A better way to do this

--- a/oneview_redfish_toolkit/api/redfish_json_validator.py
+++ b/oneview_redfish_toolkit/api/redfish_json_validator.py
@@ -15,12 +15,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import collections
+from flask_api import status
 import json
 import jsonschema
+from werkzeug.exceptions import abort
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
-from oneview_redfish_toolkit.api.errors \
-    import OneViewRedfishResourceNotFoundError
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import config
 
@@ -63,9 +62,6 @@ class RedfishJsonValidator(object):
 
             Exception:
                 ValidationError: Raises this exception on validation failure.
-
-                OneViewRedfishError: Raises this exception if
-                schema is not found.
         """
         self.validate(self.redfish, self.schema_name)
 
@@ -78,9 +74,6 @@ class RedfishJsonValidator(object):
 
             Exception:
                 ValidationError: Raises this exception on validation failure.
-
-                OneViewRedfishError: Raises this exception if
-                schema is not found.
         """
         stored_schemas = config.get_stored_schemas()
         schema_obj = RedfishJsonValidator.get_schema_obj(schema_name)
@@ -125,24 +118,19 @@ class RedfishJsonValidator(object):
 
             Returns:
                 Resource in the list.
-
-            Exception:
-                OneViewRedfishError: If the ID is not an integer.
-                OneViewRedfishResourceNotFoundError: If the resource
-                    was not found.
         """
         try:
             resource_id = int(resource_id)
         except ValueError:
-            raise OneViewRedfishError("Invalid {} ID".format(
-                self.__class__.__name__))
+            abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
+                  "Invalid {} ID".format(self.__class__.__name__))
 
         for resource in resource_list:
             if resource[resource_number_key] == resource_id:
                 return resource
 
-        raise OneViewRedfishResourceNotFoundError(
-            "Object", self.__class__.__name__)
+        abort(status.HTTP_404_NOT_FOUND,
+              "Object {} was not found.".format(self.__class__.__name__))
 
     def get_odata_type(self):
         """Retrieves odata.type from schema file
@@ -185,6 +173,7 @@ class RedfishJsonValidator(object):
             schema_obj = stored_schemas[
                 "http://redfish.dmtf.org/schemas/v1/" + schema_file]
         except KeyError:
-            raise OneViewRedfishError("{} not found".format(schema_file))
+            abort(status.HTTP_404_NOT_FOUND,
+                  "{} not found".format(schema_file))
 
         return schema_obj

--- a/oneview_redfish_toolkit/api/redfish_json_validator.py
+++ b/oneview_redfish_toolkit/api/redfish_json_validator.py
@@ -18,8 +18,8 @@ import collections
 from flask_api import status
 import json
 import jsonschema
-from werkzeug.exceptions import abort
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import config
 
@@ -122,15 +122,19 @@ class RedfishJsonValidator(object):
         try:
             resource_id = int(resource_id)
         except ValueError:
-            abort(status.HTTP_400_BAD_REQUEST,
-                  "Invalid {} ID".format(self.__class__.__name__))
+            raise OneViewRedfishException(
+                "Invalid {} ID".format(self.__class__.__name__),
+                status.HTTP_400_BAD_REQUEST
+            )
 
         for resource in resource_list:
             if resource[resource_number_key] == resource_id:
                 return resource
 
-        abort(status.HTTP_404_NOT_FOUND,
-              "Object {} was not found.".format(self.__class__.__name__))
+        raise OneViewRedfishException(
+            "Object {} was not found.".format(self.__class__.__name__),
+            status.HTTP_404_NOT_FOUND
+        )
 
     def get_odata_type(self):
         """Retrieves odata.type from schema file
@@ -160,7 +164,7 @@ class RedfishJsonValidator(object):
         """Retrieves schemas object for the schema name
 
             Retrieves the schema file content loaded
-            as a dict for the schema name receveid
+            as a dict for the schema name received
             as parameter.
 
             Returns:
@@ -173,7 +177,9 @@ class RedfishJsonValidator(object):
             schema_obj = stored_schemas[
                 "http://redfish.dmtf.org/schemas/v1/" + schema_file]
         except KeyError:
-            abort(status.HTTP_404_NOT_FOUND,
-                  "{} not found".format(schema_file))
+            raise OneViewRedfishException(
+                "{} not found".format(schema_file),
+                status.HTTP_404_NOT_FOUND
+            )
 
         return schema_obj

--- a/oneview_redfish_toolkit/api/redfish_json_validator.py
+++ b/oneview_redfish_toolkit/api/redfish_json_validator.py
@@ -14,12 +14,16 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+
 import collections
-from flask_api import status
 import json
 import jsonschema
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import config
 
@@ -122,18 +126,16 @@ class RedfishJsonValidator(object):
         try:
             resource_id = int(resource_id)
         except ValueError:
-            raise OneViewRedfishException(
-                "Invalid {} ID".format(self.__class__.__name__),
-                status.HTTP_400_BAD_REQUEST
+            raise OneViewRedfishInvalidAttributeValueException(
+                "Invalid {} ID".format(self.__class__.__name__)
             )
 
         for resource in resource_list:
             if resource[resource_number_key] == resource_id:
                 return resource
 
-        raise OneViewRedfishException(
-            "Object {} was not found.".format(self.__class__.__name__),
-            status.HTTP_404_NOT_FOUND
+        raise OneViewRedfishResourceNotFoundException(
+            "Object {} was not found.".format(self.__class__.__name__)
         )
 
     def get_odata_type(self):
@@ -177,9 +179,8 @@ class RedfishJsonValidator(object):
             schema_obj = stored_schemas[
                 "http://redfish.dmtf.org/schemas/v1/" + schema_file]
         except KeyError:
-            raise OneViewRedfishException(
-                "{} not found".format(schema_file),
-                status.HTTP_404_NOT_FOUND
+            raise OneViewRedfishResourceNotFoundException(
+                "{} not found".format(schema_file)
             )
 
         return schema_obj

--- a/oneview_redfish_toolkit/api/util/power_option.py
+++ b/oneview_redfish_toolkit/api/util/power_option.py
@@ -14,11 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
 import copy
-from flask_api import status
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
-
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 
 RESET_ALLOWABLE_VALUES_LIST = ["On", "ForceOff", "GracefulShutdown",
                                "GracefulRestart", "ForceRestart",
@@ -57,9 +59,8 @@ class OneViewPowerOption(object):
         try:
             return copy.copy(POWER_STATE_MAP[reset_type])
         except KeyError:
-            raise OneViewRedfishException(
-                "There is no mapping for {} on the OneView".format(reset_type),
-                status.HTTP_404_NOT_FOUND
+            raise OneViewRedfishResourceNotFoundException(
+                "There is no mapping for {} on the OneView".format(reset_type)
             )
 
     @staticmethod
@@ -82,9 +83,8 @@ class OneViewPowerOption(object):
                 reset_type is an unmapped value.
         """
         if reset_type in RESET_INVALID_VALUES_LIST:
-            raise OneViewRedfishException(
-                "{} not mapped to OneView".format(reset_type),
-                status.HTTP_501_NOT_IMPLEMENTED
+            raise OneViewRedfishInvalidAttributeValueException(
+                "{} not mapped to OneView".format(reset_type)
             )
 
         power_state_map = OneViewPowerOption.\

--- a/oneview_redfish_toolkit/api/util/power_option.py
+++ b/oneview_redfish_toolkit/api/util/power_option.py
@@ -16,7 +16,8 @@
 
 import copy
 from flask_api import status
-from werkzeug.exceptions import abort
+
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 RESET_ALLOWABLE_VALUES_LIST = ["On", "ForceOff", "GracefulShutdown",
@@ -56,9 +57,10 @@ class OneViewPowerOption(object):
         try:
             return copy.copy(POWER_STATE_MAP[reset_type])
         except KeyError:
-            abort(status.HTTP_400_BAD_REQUEST,
-                  "There is no mapping for {} on the OneView".format(
-                      reset_type))
+            raise OneViewRedfishException(
+                "There is no mapping for {} on the OneView".format(reset_type),
+                status.HTTP_404_NOT_FOUND
+            )
 
     @staticmethod
     def get_oneview_power_configuration(server_hardware, reset_type):
@@ -76,12 +78,14 @@ class OneViewPowerOption(object):
                 dict: Dict with OneView power configuration.
 
             Exception:
-                NotImplementedException: raises an exception if
+                OneViewRedfishException: raises an exception if
                 reset_type is an unmapped value.
         """
         if reset_type in RESET_INVALID_VALUES_LIST:
-            abort(status.HTTP_501_NOT_IMPLEMENTED,
-                  "{} not mapped to OneView".format(reset_type))
+            raise OneViewRedfishException(
+                "{} not mapped to OneView".format(reset_type),
+                status.HTTP_501_NOT_IMPLEMENTED
+            )
 
         power_state_map = OneViewPowerOption.\
             get_power_state_by_reset_type(reset_type)

--- a/oneview_redfish_toolkit/api/util/power_option.py
+++ b/oneview_redfish_toolkit/api/util/power_option.py
@@ -15,8 +15,8 @@
 # under the License.
 
 import copy
-
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
+from flask_api import status
+from werkzeug.exceptions import abort
 
 
 RESET_ALLOWABLE_VALUES_LIST = ["On", "ForceOff", "GracefulShutdown",
@@ -55,12 +55,10 @@ class OneViewPowerOption(object):
     def get_power_state_by_reset_type(reset_type):
         try:
             return copy.copy(POWER_STATE_MAP[reset_type])
-        except Exception:
-            raise OneViewRedfishError({
-                "errorCode": "INVALID_INFORMATION",
-                "message": "There is no mapping for {} on the OneView".format(
-                    reset_type
-                )})
+        except KeyError:
+            abort(status.HTTP_400_BAD_REQUEST,
+                  "There is no mapping for {} on the OneView".format(
+                      reset_type))
 
     @staticmethod
     def get_oneview_power_configuration(server_hardware, reset_type):
@@ -78,13 +76,12 @@ class OneViewPowerOption(object):
                 dict: Dict with OneView power configuration.
 
             Exception:
-                OneViewRedfishError: raises an exception if
+                NotImplementedException: raises an exception if
                 reset_type is an unmapped value.
         """
         if reset_type in RESET_INVALID_VALUES_LIST:
-            raise OneViewRedfishError({
-                "errorCode": "NOT_IMPLEMENTED",
-                "message": "{} not mapped to OneView".format(reset_type)})
+            abort(status.HTTP_501_NOT_IMPLEMENTED,
+                  "{} not mapped to OneView".format(reset_type))
 
         power_state_map = OneViewPowerOption.\
             get_power_state_by_reset_type(reset_type)

--- a/oneview_redfish_toolkit/app.py
+++ b/oneview_redfish_toolkit/app.py
@@ -36,6 +36,7 @@ from flask_api import status
 from hpOneView import HPOneViewException
 from paste.translogger import TransLogger
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.redfish_error import RedfishError
 from oneview_redfish_toolkit.api import scmb
 from oneview_redfish_toolkit.api.session_collection import SessionCollection
@@ -293,17 +294,7 @@ def main(config_file_path, logging_config_file_path,
         """Creates a Not Implemented Error response"""
         logging.error(error.description)
 
-        redfish_error = RedfishError(
-            "ActionNotSupported", error.description)
-        redfish_error.add_extended_info(
-            message_id="ActionNotSupported",
-            message_args=["action"])
-
-        error_str = redfish_error.serialize()
-        return Response(
-            response=error_str,
-            status=status.HTTP_501_NOT_IMPLEMENTED,
-            mimetype='application/json')
+        return ResponseBuilder.error_501(error)
 
     @app.errorhandler(HPOneViewException)
     def hp_oneview_client_exception(exception):
@@ -317,6 +308,12 @@ def main(config_file_path, logging_config_file_path,
             client_session.clear_session_by_token(token)
 
         return response
+
+    @app.errorhandler(OneViewRedfishException)
+    def oneview_redfish_exception(exception):
+        logging.exception(exception)
+
+        return ResponseBuilder.oneview_redfish_exception(exception)
 
     scmb.init_event_service()
 

--- a/oneview_redfish_toolkit/blueprints/chassis_collection.py
+++ b/oneview_redfish_toolkit/blueprints/chassis_collection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -39,13 +39,6 @@ def get_chassis_collection():
             JSON: Redfish json with ChassisCollection.
             When Server hardware, enclosures or racks is not found
             calls abort(404).
-
-        Exceptions:
-            OneViewRedfishResourceNotFoundError: if have some oneview resource
-            with empty value (ServerHardware, Enclosures or Racks).
-            Logs the exception and call abort(404).
-
-            Exception: Generic error, logs the exception and call abort(500).
     """
 
     # Gets all enclosures

--- a/oneview_redfish_toolkit/blueprints/computer_system.py
+++ b/oneview_redfish_toolkit/blueprints/computer_system.py
@@ -34,7 +34,6 @@ from jsonschema import ValidationError
 
 from oneview_redfish_toolkit.api.capabilities_object import CapabilitiesObject
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.redfish_json_validator \
     import RedfishJsonValidator
 from oneview_redfish_toolkit.api.util.power_option import OneViewPowerOption
@@ -55,7 +54,6 @@ def get_computer_system(uuid):
 
         Return ComputerSystem redfish JSON for a given
         server profile or server profile template UUID.
-        Logs exception of OneViewRedfishError and abort(404).
 
         Returns:
             JSON: Redfish json with ComputerSystem
@@ -63,43 +61,38 @@ def get_computer_system(uuid):
             is not found calls abort(404)
     """
 
-    try:
-        resource = _get_oneview_resource(uuid)
-        category = resource["category"]
+    resource = _get_oneview_resource(uuid)
+    category = resource["category"]
 
-        if category == 'server-profile-templates':
-            computer_system_resource = CapabilitiesObject(resource)
-        elif category == 'server-profiles':
-            server_hardware = g.oneview_client.server_hardware\
-                .get(resource["serverHardwareUri"])
-            server_hardware_type = g.oneview_client.server_hardware_types\
-                .get(resource['serverHardwareTypeUri'])
+    if category == 'server-profile-templates':
+        computer_system_resource = CapabilitiesObject(resource)
+    elif category == 'server-profiles':
+        server_hardware = g.oneview_client.server_hardware\
+            .get(resource["serverHardwareUri"])
+        server_hardware_type = g.oneview_client.server_hardware_types\
+            .get(resource['serverHardwareTypeUri'])
 
-            computer_system_service = ComputerSystemService(g.oneview_client)
-            drives = _get_drives_from_sp(resource)
-            spt_uuid = computer_system_service.\
-                get_server_profile_template_from_sp(resource["uri"])
+        computer_system_service = ComputerSystemService(g.oneview_client)
+        drives = _get_drives_from_sp(resource)
+        spt_uuid = computer_system_service.\
+            get_server_profile_template_from_sp(resource["uri"])
 
-            manager_uuid = get_manager_uuid(resource['serverHardwareTypeUri'])
+        manager_uuid = get_manager_uuid(resource['serverHardwareTypeUri'])
 
-            # Build Computer System object and validates it
-            computer_system_resource = ComputerSystem(server_hardware,
-                                                      server_hardware_type,
-                                                      resource,
-                                                      drives,
-                                                      spt_uuid,
-                                                      manager_uuid)
-        else:
-            raise OneViewRedfishError(
-                'Computer System UUID {} not found'.format(uuid))
+        # Build Computer System object and validates it
+        computer_system_resource = ComputerSystem(server_hardware,
+                                                  server_hardware_type,
+                                                  resource,
+                                                  drives,
+                                                  spt_uuid,
+                                                  manager_uuid)
+    else:
+        abort(status.HTTP_404_NOT_FOUND,
+              'Computer System UUID {} not found'.format(uuid))
 
-        return ResponseBuilder.success(
-            computer_system_resource,
-            {"ETag": "W/" + resource["eTag"]})
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
+    return ResponseBuilder.success(
+        computer_system_resource,
+        {"ETag": "W/" + resource["eTag"]})
 
 
 @computer_system.route("/redfish/v1/Systems/<uuid>/"
@@ -113,52 +106,31 @@ def change_power_state(uuid):
 
         Returns:
             JSON: Redfish JSON with ComputerSystem ResetType.
-
-        Exceptions:
-            HPOneViewException: When some OneView resource was not found.
-            return abort(404)
-
-            OneViewRedfishError: When occur a power state mapping error.
-            return abort(400)
-
-            Exception: Unexpected error.
-            return abort(500)
     """
 
     try:
-        try:
-            reset_type = request.get_json()["ResetType"]
-        except KeyError:
-            invalid_key = list(request.get_json())[0]  # gets invalid key name
-            raise OneViewRedfishError(
-                {"errorCode": "INVALID_INFORMATION",
-                 "message": "Invalid JSON key: {}".format(invalid_key)})
+        reset_type = request.get_json()["ResetType"]
+    except KeyError:
+        invalid_key = list(request.get_json())[0]  # gets invalid key name
+        abort(status.HTTP_400_BAD_REQUEST,
+              "Invalid JSON key: {}".format(invalid_key))
 
-        # Gets ServerHardware for given UUID
-        profile = g.oneview_client.server_profiles.get(uuid)
-        sh = g.oneview_client.server_hardware.get(profile["serverHardwareUri"])
+    # Gets ServerHardware for given UUID
+    profile = g.oneview_client.server_profiles.get(uuid)
+    sh = g.oneview_client.server_hardware.get(profile["serverHardwareUri"])
 
-        oneview_power_configuration = \
-            OneViewPowerOption.get_oneview_power_configuration(
-                sh, reset_type)
+    oneview_power_configuration = \
+        OneViewPowerOption.get_oneview_power_configuration(
+            sh, reset_type)
 
-        # Changes the ServerHardware power state
-        g.oneview_client.server_hardware.update_power_state(
-            oneview_power_configuration, sh["uuid"])
+    # Changes the ServerHardware power state
+    g.oneview_client.server_hardware.update_power_state(
+        oneview_power_configuration, sh["uuid"])
 
-        return Response(
-            response='{"ResetType": "%s"}' % reset_type,
-            status=status.HTTP_200_OK,
-            mimetype='application/json')
-
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Mapping error: {}'.format(e))
-
-        if e.msg["errorCode"] == "NOT_IMPLEMENTED":
-            abort(status.HTTP_501_NOT_IMPLEMENTED, e.msg['message'])
-        else:
-            abort(status.HTTP_400_BAD_REQUEST, e.msg['message'])
+    return Response(
+        response='{"ResetType": "%s"}' % reset_type,
+        status=status.HTTP_200_OK,
+        mimetype='application/json')
 
 
 @computer_system.route(
@@ -174,10 +146,7 @@ def remove_computer_system(uuid):
     sh_uuid = profile['serverHardwareUri']
     if sh_uuid:
         service = ComputerSystemService(g.oneview_client)
-        try:
-            service.power_off_server_hardware(sh_uuid)
-        except OneViewRedfishError as e:
-            abort(status.HTTP_403_FORBIDDEN, e.msg)
+        service.power_off_server_hardware(sh_uuid)
 
     # Deletes server profile for given UUID
     response = None
@@ -211,7 +180,7 @@ def remove_computer_system(uuid):
 def create_composed_system():
     if not request.is_json:
         abort(status.HTTP_400_BAD_REQUEST,
-              "The request content should be a valida JSON")
+              "The request content should be a valid JSON")
 
     body = request.get_json()
     result_location_uri = None
@@ -270,14 +239,14 @@ def create_composed_system():
                 lambda result, msg: result + msg["message"] + "\n",
                 task["taskErrors"],
                 "")
-            raise OneViewRedfishError(err_msg)
+            abort(status.HTTP_400_BAD_REQUEST, err_msg)
 
     except ValidationError as e:
         abort(status.HTTP_400_BAD_REQUEST, e.message)
     except KeyError as e:
         abort(status.HTTP_400_BAD_REQUEST,
               "Trying access an invalid key {}".format(e.args))
-    except (HPOneViewTaskError, OneViewRedfishError) as e:
+    except HPOneViewTaskError as e:
         abort(status.HTTP_403_FORBIDDEN, e.msg)
 
     if not result_location_uri:
@@ -317,7 +286,8 @@ def _get_oneview_resource(uuid):
             else:
                 raise  # Raise any unexpected errors
 
-    raise OneViewRedfishError("Could not find computer system with id " + uuid)
+    abort(status.HTTP_404_NOT_FOUND,
+          "Could not find computer system with id " + uuid)
 
 
 def _get_system_resource_blocks(ids):

--- a/oneview_redfish_toolkit/blueprints/ethernet_interface.py
+++ b/oneview_redfish_toolkit/blueprints/ethernet_interface.py
@@ -14,10 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from flask import abort
 from flask import Blueprint
 from flask import g
 from flask_api import status
-from werkzeug.exceptions import abort
 
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
 from oneview_redfish_toolkit.api.ethernet_interface import EthernetInterface

--- a/oneview_redfish_toolkit/blueprints/event_service.py
+++ b/oneview_redfish_toolkit/blueprints/event_service.py
@@ -69,8 +69,6 @@ def get_event_service():
         Returns:
             JSON: JSON with EventService.
 
-        Exceptions:
-            OneViewRedfishError: General error.
     """
     evs = EventService(util.get_delivery_retry_attempts(),
                        util.get_delivery_retry_interval())
@@ -91,11 +89,8 @@ def execute_test_event_action():
             JSON: JSON containing the EventType.
 
         Exceptions:
-            OneViewRedfishError: When an invalid JSON is received.
-            return abort(400)
-
-            Exception: Unexpected error.
-            return abort(500)
+            Exception: Missing EventType property.
+            Return Bad Request status(400)
     """
 
     if not config.auth_mode_is_conf():

--- a/oneview_redfish_toolkit/blueprints/manager.py
+++ b/oneview_redfish_toolkit/blueprints/manager.py
@@ -25,7 +25,6 @@ from flask_api import status
 from hpOneView.exceptions import HPOneViewException
 
 # Own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.manager import Manager
 from oneview_redfish_toolkit import client_session
 from oneview_redfish_toolkit import multiple_oneview
@@ -82,8 +81,3 @@ def get_managers(uuid):
         # In case of error log exception and abort
         logging.exception(e)
         abort(status.HTTP_404_NOT_FOUND, "Manager not found")
-
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)

--- a/oneview_redfish_toolkit/blueprints/network_adapter.py
+++ b/oneview_redfish_toolkit/blueprints/network_adapter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -25,10 +25,7 @@ from flask import Response
 from flask_api import status
 from hpOneView.exceptions import HPOneViewException
 
-# own libs
-
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishResourceNotFoundError
+# Own libs
 from oneview_redfish_toolkit.api.network_adapter import NetworkAdapter
 
 
@@ -63,8 +60,8 @@ def get_network_adapter(uuid, device_id):
 
         if (device_id_validation - 1) < 0 or (device_id_validation - 1) >= \
             len(server_hardware["portMap"]["deviceSlots"]):
-            raise OneViewRedfishResourceNotFoundError(
-                device_id, "Network adapter")
+            abort(status.HTTP_404_NOT_FOUND,
+                  "Network adapter id {} not found.".format(device_id))
 
         na = NetworkAdapter(device_id, server_hardware)
 
@@ -79,9 +76,6 @@ def get_network_adapter(uuid, device_id):
         logging.exception(
             "Failed to convert device id {} to integer.".format(device_id))
         abort(status.HTTP_404_NOT_FOUND, "Network adapter not found")
-    except OneViewRedfishResourceNotFoundError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
     except HPOneViewException as e:
         # In case of Oneview error log exception and abort
         logging.exception(e)
@@ -90,7 +84,3 @@ def get_network_adapter(uuid, device_id):
         else:
             # Any other Oneview Exception
             abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
-    except Exception as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/oneview_redfish_toolkit/blueprints/network_device_function.py
+++ b/oneview_redfish_toolkit/blueprints/network_device_function.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -25,12 +25,7 @@ from flask import Response
 from flask_api import status
 from hpOneView.exceptions import HPOneViewException
 
-# own libs
-
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishError
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishResourceNotFoundError
+# Own libs
 from oneview_redfish_toolkit.api.network_device_function import \
     NetworkDeviceFunction
 
@@ -70,8 +65,8 @@ def get_network_device_function(uuid, device_id, device_function_id):
         # Final validation of device_id
         if device_id_validation - 1 < 0 or (device_id_validation - 1) >= \
             len(server_hardware["portMap"]["deviceSlots"]):
-            raise OneViewRedfishResourceNotFoundError(
-                device_id, "Network interface")
+            abort(status.HTTP_404_NOT_FOUND,
+                  "Network interface id {} not found.".format(device_id))
 
         ndf = NetworkDeviceFunction(
             device_id, device_function_id, server_hardware)
@@ -87,12 +82,6 @@ def get_network_device_function(uuid, device_id, device_function_id):
         logging.exception(
             "Failed to convert device id {} to integer.".format(device_id))
         abort(status.HTTP_404_NOT_FOUND, "Network interface not found")
-    except OneViewRedfishResourceNotFoundError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
-    except OneViewRedfishError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
     except HPOneViewException as e:
         # In case of error log exception and abort
         logging.exception(e)
@@ -100,7 +89,3 @@ def get_network_device_function(uuid, device_id, device_function_id):
             abort(status.HTTP_404_NOT_FOUND, "Server hardware not found")
         else:
             abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
-    except Exception as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/oneview_redfish_toolkit/blueprints/network_interface.py
+++ b/oneview_redfish_toolkit/blueprints/network_interface.py
@@ -23,10 +23,8 @@ from flask import Blueprint
 from flask import g
 from flask_api import status
 
-# own libs
+# Own libs
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishResourceNotFoundError
 from oneview_redfish_toolkit.api.network_interface import NetworkInterface
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
@@ -65,8 +63,8 @@ def get_network_interface(server_profile_uuid, device_id):
 
         if (device_id_validation - 1) < 0 or (device_id_validation - 1) >= \
                 len(server_hardware["portMap"]["deviceSlots"]):
-            raise OneViewRedfishResourceNotFoundError(
-                device_id, "Network interface")
+            abort(status.HTTP_404_NOT_FOUND,
+                  "Network interface id {} not found.".format(device_id))
 
         ni = NetworkInterface(device_id, profile, server_hardware)
 
@@ -77,6 +75,3 @@ def get_network_interface(server_profile_uuid, device_id):
         logging.exception(
             "Failed to convert device id {} to integer.".format(device_id))
         abort(status.HTTP_404_NOT_FOUND, "Network interface not found")
-    except OneViewRedfishResourceNotFoundError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)

--- a/oneview_redfish_toolkit/blueprints/network_port.py
+++ b/oneview_redfish_toolkit/blueprints/network_port.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -23,14 +23,8 @@ from flask import Blueprint
 from flask import g
 from flask import Response
 from flask_api import status
-from hpOneView.exceptions import HPOneViewException
 
-# own libs
-
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishError
-from oneview_redfish_toolkit.api.errors import \
-    OneViewRedfishResourceNotFoundError
+# Own libs
 from oneview_redfish_toolkit.api.network_port import \
     NetworkPort
 
@@ -69,8 +63,8 @@ def get_network_port(uuid, device_id, port_id):
         # Final validation of device_id
         if device_id_validation - 1 < 0 or (device_id_validation - 1) >= \
             len(server_hardware["portMap"]["deviceSlots"]):
-            raise OneViewRedfishResourceNotFoundError(
-                device_id, "Network adapter")
+            abort(status.HTTP_404_NOT_FOUND,
+                  "Network adapter id {} not found".format(device_id))
 
         np = NetworkPort(device_id, port_id, server_hardware)
 
@@ -85,20 +79,3 @@ def get_network_port(uuid, device_id, port_id):
         logging.exception(
             "Failed to convert device id {} to integer.".format(device_id))
         abort(status.HTTP_404_NOT_FOUND, "Network adapter not found")
-    except OneViewRedfishResourceNotFoundError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
-    except OneViewRedfishError as e:
-        logging.exception(e.msg)
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
-    except HPOneViewException as e:
-        # In case of error log exception and abort
-        logging.exception(e)
-        if e.oneview_response['errorCode'] == "RESOURCE_NOT_FOUND":
-            abort(status.HTTP_404_NOT_FOUND, "Server hardware not found")
-        else:
-            abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
-    except Exception as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/oneview_redfish_toolkit/blueprints/processor.py
+++ b/oneview_redfish_toolkit/blueprints/processor.py
@@ -14,9 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# Python libs
-import logging
-
 # 3rd party libs
 from flask import abort
 from flask import Blueprint
@@ -24,7 +21,6 @@ from flask import g
 from flask_api import status
 
 # Own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.processor import Processor
 from oneview_redfish_toolkit.api.resource_block_collection \
     import ResourceBlockCollection
@@ -47,23 +43,19 @@ def get_processor(uuid, id):
     """
 
     try:
-        try:
-            processor_id = int(id)
-        except Exception as e:
-            raise OneViewRedfishError("Invalid processor identifier")
+        processor_id = int(id)
+    except ValueError as e:
+        abort(status.HTTP_400_BAD_REQUEST,
+              "Cannot convert processor_id {} to integer".format(id))
 
-        server_hardware = g.oneview_client.server_hardware.get(uuid)
-        processor_count = server_hardware["processorCount"]
+    server_hardware = g.oneview_client.server_hardware.get(uuid)
+    processor_count = server_hardware["processorCount"]
 
-        if processor_id < 1 or processor_id > processor_count:
-            raise OneViewRedfishError("Invalid processor identifier")
+    if processor_id < 1 or processor_id > processor_count:
+        abort(status.HTTP_400_BAD_REQUEST,
+              "Invalid processor identifier {}".format(processor_id))
 
-        processor = Processor(server_hardware, str(processor_id))
+    processor = Processor(server_hardware, str(processor_id))
 
-        return ResponseBuilder.success(
-            processor, {"ETag": "W/" + server_hardware["eTag"]})
-
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
+    return ResponseBuilder.success(
+        processor, {"ETag": "W/" + server_hardware["eTag"]})

--- a/oneview_redfish_toolkit/blueprints/resource_block.py
+++ b/oneview_redfish_toolkit/blueprints/resource_block.py
@@ -22,7 +22,6 @@ from flask import g
 from flask_api import status
 
 from hpOneView.exceptions import HPOneViewException
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.resource_block import ResourceBlock
 from oneview_redfish_toolkit.api.resource_block_computer_system \
     import ResourceBlockComputerSystem
@@ -57,51 +56,45 @@ def get_resource_block(uuid):
         Returns:
             JSON: Redfish json with ResourceBlock.
     """
-    try:
-        zone_service = ZoneService(g.oneview_client)
-        resource = _get_oneview_resource(uuid)
-        category = resource["category"]
+    zone_service = ZoneService(g.oneview_client)
+    resource = _get_oneview_resource(uuid)
+    category = resource["category"]
 
-        if category == "server-hardware":
-            result_resource_block = _build_computer_system_resource_block(
-                uuid, resource)
+    if category == "server-hardware":
+        result_resource_block = _build_computer_system_resource_block(
+            uuid, resource)
 
-        elif category == "server-profile-templates":
-            zone_ids = zone_service.get_zone_ids_by_templates([resource])
-            if not zone_ids:
-                raise OneViewRedfishError("Zone not found "
-                                          "to ResourceBlock {}".format(uuid))
+    elif category == "server-profile-templates":
+        zone_ids = zone_service.get_zone_ids_by_templates([resource])
+        if not zone_ids:
+            abort(status.HTTP_404_NOT_FOUND,
+                  "Zone not found to ResourceBlock {}".format(uuid))
 
-            result_resource_block = \
-                ServerProfileTemplateResourceBlock(uuid, resource, zone_ids)
+        result_resource_block = \
+            ServerProfileTemplateResourceBlock(uuid, resource, zone_ids)
 
-        elif category == "drives":
-            drive_uuid = resource["uri"].split("/")[-1]
-            drive_index_trees_uri = \
-                "/rest/index/trees/rest/drives/{}?parentDepth=3"
-            drive_index_trees = g.oneview_client.connection.get(
-                drive_index_trees_uri.format(drive_uuid))
+    elif category == "drives":
+        drive_uuid = resource["uri"].split("/")[-1]
+        drive_index_trees_uri = \
+            "/rest/index/trees/rest/drives/{}?parentDepth=3"
+        drive_index_trees = g.oneview_client.connection.get(
+            drive_index_trees_uri.format(drive_uuid))
 
-            server_profile_templs = \
-                g.oneview_client.server_profile_templates.get_all()
+        server_profile_templs = \
+            g.oneview_client.server_profile_templates.get_all()
 
-            zone_ids = zone_service.get_zone_ids_by_templates(
-                server_profile_templs)
+        zone_ids = zone_service.get_zone_ids_by_templates(
+            server_profile_templs)
 
-            result_resource_block = StorageResourceBlock(
-                resource, drive_index_trees, zone_ids)
+        result_resource_block = StorageResourceBlock(
+            resource, drive_index_trees, zone_ids)
 
-        else:
-            raise OneViewRedfishError('Resource block not found')
+    else:
+        abort(status.HTTP_404_NOT_FOUND, 'Resource block not found')
 
-        return ResponseBuilder.success(
-            result_resource_block,
-            {"ETag": "W/" + resource["eTag"]})
-
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
+    return ResponseBuilder.success(
+        result_resource_block,
+        {"ETag": "W/" + resource["eTag"]})
 
 
 @resource_block.route(
@@ -144,20 +137,19 @@ def get_resource_block_ethernet_interface(uuid, id):
             JSON: Redfish json with ResourceBlock.
     """
 
-    try:
-        server_profile_template = \
-            g.oneview_client.server_profile_templates.get(uuid)
+    server_profile_template = \
+        g.oneview_client.server_profile_templates.get(uuid)
 
-        conn_settings = server_profile_template["connectionSettings"]
-        connection = None
+    conn_settings = server_profile_template["connectionSettings"]
+    connection = None
 
-        for conn in conn_settings["connections"]:
-            if str(conn["id"]) == id:
-                connection = conn
-                break
+    for conn in conn_settings["connections"]:
+        if str(conn["id"]) == id:
+            connection = conn
+            break
 
-        if not connection:
-            raise OneViewRedfishError("Ethernet interface not found")
+    if not connection:
+        abort(status.HTTP_404_NOT_FOUND, "Ethernet interface not found")
 
         network = \
             g.oneview_client.index_resources.get(connection["networkUri"])
@@ -165,14 +157,9 @@ def get_resource_block_ethernet_interface(uuid, id):
         ethernet_interface = ResourceBlockEthernetInterface(
             server_profile_template, connection, network)
 
-        return ResponseBuilder.success(
-            ethernet_interface,
-            {"ETag": "W/" + server_profile_template["eTag"]})
-
-    except OneViewRedfishError as e:
-        # In case of error log exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, e.msg)
+    return ResponseBuilder.success(
+        ethernet_interface,
+        {"ETag": "W/" + server_profile_template["eTag"]})
 
 
 def _get_oneview_resource(uuid):
@@ -209,7 +196,8 @@ def _get_oneview_resource(uuid):
             else:
                 raise  # Raise any unexpected errors
 
-    raise OneViewRedfishError("Could not find resource block with id " + uuid)
+    abort(status.HTTP_404_NOT_FOUND,
+          "Could not find resource block with id " + uuid)
 
 
 def _build_computer_system_resource_block(uuid, server_hardware):

--- a/oneview_redfish_toolkit/blueprints/session.py
+++ b/oneview_redfish_toolkit/blueprints/session.py
@@ -26,7 +26,6 @@ from flask_api import status
 from hpOneView.exceptions import HPOneViewException
 
 # own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.session import Session
 from oneview_redfish_toolkit.api.session_collection import SessionCollection
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
@@ -83,8 +82,6 @@ def post_session():
             HPOneViewException: Invalid username or password.
             return abort(401)
 
-            OneViewRedfishError: When occur a credential key mapping error.
-            return abort(400)
     """
 
     try:
@@ -93,10 +90,9 @@ def post_session():
             username = body["UserName"]
             password = body["Password"]
         except Exception:
-            raise OneViewRedfishError(
-                {"errorCode": "INVALID_INFORMATION",
-                 "message": "Invalid JSON key. The JSON request body"
-                            " must have the keys UserName and Password"})
+            error_message = "Invalid JSON key. The JSON request body " \
+                            "must have the keys UserName and Password"
+            abort(status.HTTP_400_BAD_REQUEST, error_message)
 
         token, session_id = client_session.login(username, password)
 
@@ -110,6 +106,3 @@ def post_session():
     except HPOneViewException as e:
         logging.exception('Unauthorized error: {}'.format(e))
         abort(status.HTTP_401_UNAUTHORIZED)
-    except OneViewRedfishError as e:
-        logging.exception('Mapping error: {}'.format(e))
-        abort(status.HTTP_400_BAD_REQUEST, e.msg['message'])

--- a/oneview_redfish_toolkit/blueprints/session_service.py
+++ b/oneview_redfish_toolkit/blueprints/session_service.py
@@ -32,8 +32,5 @@ def get_session_service():
 
         Returns:
             JSON: JSON with SessionService.
-
-        Exceptions:
-            OneViewRedfishError: General error.
     """
     return ResponseBuilder.success(SessionService())

--- a/oneview_redfish_toolkit/blueprints/storage.py
+++ b/oneview_redfish_toolkit/blueprints/storage.py
@@ -15,12 +15,12 @@
 # under the License.
 
 # 3rd party libs
+from flask import abort
 from flask import Blueprint
 from flask import g
 
 # own libs
 from flask_api import status
-from werkzeug.exceptions import abort
 
 from oneview_redfish_toolkit.api.computer_system import ComputerSystem
 from oneview_redfish_toolkit.api.storage import Storage

--- a/oneview_redfish_toolkit/blueprints/storage_composition_details.py
+++ b/oneview_redfish_toolkit/blueprints/storage_composition_details.py
@@ -14,10 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from flask import abort
 from flask import Blueprint
 from flask import g
 from flask_api import status
-from werkzeug.exceptions import abort
 
 from oneview_redfish_toolkit.api.resource_block import ResourceBlock
 from oneview_redfish_toolkit.api.storage_composition_details import \

--- a/oneview_redfish_toolkit/blueprints/subscription.py
+++ b/oneview_redfish_toolkit/blueprints/subscription.py
@@ -25,7 +25,6 @@ from flask_api import status
 from jsonschema.exceptions import ValidationError
 import validators
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.subscription import Subscription
 from oneview_redfish_toolkit import util
 
@@ -52,79 +51,65 @@ def add_subscription():
             JSON: JSON with Subscription information.
 
         Exception:
-            OneViewRedfishError: When occur a key mapping error.
+            KeyError: When occur a key mapping error.
             return abort(400)
 
-            Exception: Unexpected error.
-            return abort(500)
     """
+
+    # get Destination, EventTypes and Context from post
+    # generate subscription uuid
+    # add subscription in subscriptions_by_type
+    # add subscription in all_subscriptions
+
     try:
-        # get Destination, EventTypes and Context from post
-        # generate subscription uuid
-        # add subscription in subscriptions_by_type
-        # add subscription in all_subscriptions
+        body = request.get_json()
+        destination = body["Destination"]
 
-        try:
-            body = request.get_json()
-            destination = body["Destination"]
+        if not validators.url(destination):
+            abort(status.HTTP_400_BAD_REQUEST,
+                  "Destination must be an URI.")
 
-            if not validators.url(destination):
-                raise OneViewRedfishError(
-                    {"errorCode": "INVALID_INFORMATION",
-                     "message": "Destination must be an URI."})
+        event_types = body["EventTypes"]
 
-            event_types = body["EventTypes"]
+        if not event_types:
+            abort(status.HTTP_400_BAD_REQUEST,
+                  "EventTypes cannot be empty.")
 
-            if not event_types:
-                raise OneViewRedfishError(
-                    {"errorCode": "INVALID_INFORMATION",
-                     "message": "EventTypes cannot be empty."})
+        context = body.get("Context")
+    except KeyError:
+        error_message = "Invalid JSON key. The JSON request body " \
+                        "must have the keys Destination and EventTypes. " \
+                        "The Context is optional."
+        abort(status.HTTP_400_BAD_REQUEST, error_message)
 
-            context = body.get("Context")
-        except KeyError:
-            raise OneViewRedfishError(
-                {"errorCode": "INVALID_INFORMATION",
-                 "message": "Invalid JSON key. The JSON request body"
-                            " must have the keys Destination and EventTypes."
-                            " The Context is optional."})
+    subscription_id = str(uuid.uuid1())
 
-        subscription_id = str(uuid.uuid1())
+    try:
+        # Build Subscription object and validates it
+        sc = Subscription(subscription_id, destination,
+                          event_types, context)
+    except ValidationError:
+        error_message = "Invalid EventType. The EventTypes are StatusChange, " \
+                        "ResourceUpdated, ResourceAdded, ResourceRemoved and Alert."
+        abort(status.HTTP_400_BAD_REQUEST, error_message)
 
-        try:
-            # Build Subscription object and validates it
-            sc = Subscription(subscription_id, destination,
-                              event_types, context)
-        except ValidationError:
-            raise OneViewRedfishError(
-                {"errorCode": "INVALID_INFORMATION",
-                 "message": "Invalid EventType. The EventTypes are "
-                            "StatusChange, ResourceUpdated, ResourceAdded,"
-                            " ResourceRemoved and Alert."})
+    for event_type in sc.get_event_types():
+        util.get_subscriptions_by_type()[event_type][subscription_id] = sc
 
-        for event_type in sc.get_event_types():
-            util.get_subscriptions_by_type()[event_type][subscription_id] = sc
+    util.get_all_subscriptions()[subscription_id] = sc
 
-        util.get_all_subscriptions()[subscription_id] = sc
+    # Build redfish json
+    json_str = sc.serialize()
 
-        # Build redfish json
-        json_str = sc.serialize()
-
-        # Build response and returns
-        response = Response(
-            response=json_str,
-            status=status.HTTP_201_CREATED,
-            mimetype="application/json")
-        response.headers.add(
-            "Location", "/redfish/v1/EventService/EventSubscriptions/"
-                        "{}".format(subscription_id))
-        return response
-
-    except OneViewRedfishError as e:
-        logging.exception(e)
-        abort(status.HTTP_400_BAD_REQUEST, e.msg['message'])
-    except Exception as e:
-        logging.exception(e)
-        return abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
+    # Build response and returns
+    response = Response(
+        response=json_str,
+        status=status.HTTP_201_CREATED,
+        mimetype="application/json")
+    response.headers.add(
+        "Location", "/redfish/v1/EventService/EventSubscriptions/"
+                    "{}".format(subscription_id))
+    return response
 
 
 @subscription.route(

--- a/oneview_redfish_toolkit/blueprints/thermal.py
+++ b/oneview_redfish_toolkit/blueprints/thermal.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (2017) Hewlett Packard Enterprise Development LP
+# Copyright (2017-2018) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -26,7 +26,6 @@ from flask_api import status
 
 # own libs
 from hpOneView.exceptions import HPOneViewException
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit.api.thermal import Thermal
 from oneview_redfish_toolkit import category_resource
 
@@ -64,7 +63,7 @@ def get_thermal(uuid):
             if index_obj:
                 category = index_obj[0]["category"]
             else:
-                raise OneViewRedfishError('Cannot find Index resource')
+                abort(status.HTTP_404_NOT_FOUND, 'Cannot find Index resource')
 
         if category == 'server-hardware':
             server_hardware = g.oneview_client.server_hardware. \
@@ -79,7 +78,7 @@ def get_thermal(uuid):
                 get_device_topology(uuid)
             thrml = Thermal(rack, uuid, 'Rack')
         else:
-            raise OneViewRedfishError('OneView resource not found')
+            abort(status.HTTP_404_NOT_FOUND, 'OneView resource not found')
 
         json_str = thrml.serialize()
 
@@ -95,14 +94,3 @@ def get_thermal(uuid):
             abort(status.HTTP_404_NOT_FOUND, "Resource not found")
         else:
             abort(status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-    except OneViewRedfishError as e:
-        # In case of error print exception and abort
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_404_NOT_FOUND, "Resource not found")
-
-    except Exception as e:
-        # In case of error print exception and abort
-        logging.exception(e)
-        logging.exception('Unexpected error: {}'.format(e))
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/oneview_redfish_toolkit/blueprints/util/response_builder.py
+++ b/oneview_redfish_toolkit/blueprints/util/response_builder.py
@@ -58,6 +58,14 @@ class ResponseBuilder(object):
         return handler_method_to_call(error_desc)
 
     @staticmethod
+    def oneview_redfish_exception(exception):
+        method_name = 'error_' + str(exception.status_code_error)
+        handler_method_to_call = getattr(ResponseBuilder, method_name)
+
+        error_desc = ErrorDescription(description=exception.msg)
+        return handler_method_to_call(error_desc)
+
+    @staticmethod
     def error_401(error):
         redfish_error = RedfishError("GeneralError", error.description)
         return ResponseBuilder.response(redfish_error,
@@ -86,3 +94,14 @@ class ResponseBuilder(object):
         redfish_error.add_extended_info("InternalError")
         return ResponseBuilder.response(redfish_error,
                                         status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @staticmethod
+    def error_501(error):
+        redfish_error = RedfishError(
+            "ActionNotSupported", error.description)
+        redfish_error.add_extended_info(
+            message_id="ActionNotSupported",
+            message_args=["action"])
+
+        return ResponseBuilder.response(redfish_error,
+                                        status.HTTP_501_NOT_IMPLEMENTED)

--- a/oneview_redfish_toolkit/config.py
+++ b/oneview_redfish_toolkit/config.py
@@ -23,9 +23,9 @@ import json
 import logging
 import logging.config
 import os
-from werkzeug.exceptions import abort
 
 # Modules own libs
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import connection
 from oneview_redfish_toolkit import util
@@ -174,8 +174,10 @@ def load_config(conf_file):
 
         load_schemas(get_schemas_path())
     except Exception as e:
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
-              'Failed to connect to OneView: {}'.format(e))
+        raise OneViewRedfishException(
+            'Failed to connect to OneView: {}'.format(e),
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
 
 def load_conf_file(conf_file):
@@ -191,8 +193,10 @@ def load_conf_file(conf_file):
     """
 
     if not os.path.isfile(conf_file):
-        abort(status.HTTP_404_NOT_FOUND,
-              "File {} not found.".format(conf_file))
+        raise OneViewRedfishException(
+            "File {} not found.".format(conf_file),
+            status.HTTP_404_NOT_FOUND
+        )
 
     config = configparser.ConfigParser()
     config.optionxform = str
@@ -223,11 +227,16 @@ def load_registry(registry_dir, registries):
     """
 
     if os.path.isdir(registry_dir) is False:
-        abort(status.HTTP_404_NOT_FOUND,
-              "Directory {} not found.".format(registry_dir))
+        raise OneViewRedfishException(
+            "Directory {} not found.".format(registry_dir),
+            status.HTTP_404_NOT_FOUND
+        )
+
     if os.access(registry_dir, os.R_OK) is False:
-        abort(status.HTTP_500_INTERNAL_SERVER_ERROR,
-              "Directory {} not found.".format(registry_dir))
+        raise OneViewRedfishException(
+            "Directory {} not found.".format(registry_dir),
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
     registries_dict = collections.OrderedDict()
     for key in registries:
@@ -235,7 +244,10 @@ def load_registry(registry_dir, registries):
             with open(registry_dir + '/' + registries[key]) as f:
                 registries_dict[key] = json.load(f)
         except Exception:
-            abort(status.HTTP_404_NOT_FOUND, "File {} not found.")
+            raise OneViewRedfishException(
+                "File {} not found.",
+                status.HTTP_404_NOT_FOUND
+            )
 
     return registries_dict
 
@@ -255,8 +267,10 @@ def load_schemas(schema_dir):
     schema_paths = glob.glob(schema_dir + '/*.json')
 
     if not schema_paths:
-        abort(status.HTTP_404_NOT_FOUND,
-              "JSON Schemas file not found.")
+        raise OneViewRedfishException(
+            "JSON Schemas file not found.",
+            status.HTTP_404_NOT_FOUND
+        )
 
     stored_schemas = dict()
 

--- a/oneview_redfish_toolkit/config.py
+++ b/oneview_redfish_toolkit/config.py
@@ -17,7 +17,6 @@
 # Python libs
 import collections
 import configparser
-from flask_api import status
 import glob
 import json
 import logging
@@ -25,7 +24,10 @@ import logging.config
 import os
 
 # Modules own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import connection
 from oneview_redfish_toolkit import util
@@ -175,8 +177,7 @@ def load_config(conf_file):
         load_schemas(get_schemas_path())
     except Exception as e:
         raise OneViewRedfishException(
-            'Failed to connect to OneView: {}'.format(e),
-            status.HTTP_500_INTERNAL_SERVER_ERROR
+            'Failed to connect to OneView: {}'.format(e)
         )
 
 
@@ -193,9 +194,8 @@ def load_conf_file(conf_file):
     """
 
     if not os.path.isfile(conf_file):
-        raise OneViewRedfishException(
-            "File {} not found.".format(conf_file),
-            status.HTTP_404_NOT_FOUND
+        raise OneViewRedfishResourceNotFoundException(
+            "File {} not found.".format(conf_file)
         )
 
     config = configparser.ConfigParser()
@@ -227,15 +227,13 @@ def load_registry(registry_dir, registries):
     """
 
     if os.path.isdir(registry_dir) is False:
-        raise OneViewRedfishException(
-            "Directory {} not found.".format(registry_dir),
-            status.HTTP_404_NOT_FOUND
+        raise OneViewRedfishResourceNotFoundException(
+            "Directory {} not found.".format(registry_dir)
         )
 
     if os.access(registry_dir, os.R_OK) is False:
-        raise OneViewRedfishException(
-            "Directory {} not found.".format(registry_dir),
-            status.HTTP_500_INTERNAL_SERVER_ERROR
+        raise OneViewRedfishResourceNotFoundException(
+            "Directory {} not found.".format(registry_dir)
         )
 
     registries_dict = collections.OrderedDict()
@@ -244,9 +242,8 @@ def load_registry(registry_dir, registries):
             with open(registry_dir + '/' + registries[key]) as f:
                 registries_dict[key] = json.load(f)
         except Exception:
-            raise OneViewRedfishException(
-                "File {} not found.",
-                status.HTTP_404_NOT_FOUND
+            raise OneViewRedfishResourceNotFoundException(
+                "File {} not found.".format(registries[key])
             )
 
     return registries_dict
@@ -267,9 +264,8 @@ def load_schemas(schema_dir):
     schema_paths = glob.glob(schema_dir + '/*.json')
 
     if not schema_paths:
-        raise OneViewRedfishException(
-            "JSON Schemas file not found.",
-            status.HTTP_404_NOT_FOUND
+        raise OneViewRedfishResourceNotFoundException(
+            "JSON Schemas file not found."
         )
 
     stored_schemas = dict()

--- a/oneview_redfish_toolkit/connection.py
+++ b/oneview_redfish_toolkit/connection.py
@@ -20,7 +20,6 @@ import logging
 import logging.config
 import ssl
 import time
-from werkzeug.exceptions import abort
 
 # 3rd party libs
 from flask import request
@@ -29,6 +28,7 @@ from hpOneView.oneview_client import OneViewClient
 from http.client import HTTPSConnection
 
 # Modules own libs
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit import config
 
 
@@ -78,7 +78,10 @@ def check_oneview_availability(oneview_ip):
             if status_ov['state'] != 'OK':
                 message = "OneView state is not OK at {}".format(
                     oneview_ip)
-                abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
+                raise OneViewRedfishException(
+                    message,
+                    status.HTTP_500_INTERNAL_SERVER_ERROR
+                )
 
             return
         except Exception as e:
@@ -91,7 +94,9 @@ def check_oneview_availability(oneview_ip):
 
     message = "After {} attempts OneView is unreachable at {}".format(
         attempts, oneview_ip)
-    abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
+    raise \
+        OneViewRedfishException(message,
+                                status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 def request_oneview(oneview_ip, rest_url):
@@ -110,7 +115,9 @@ def request_oneview(oneview_ip, rest_url):
         if response.status != status.HTTP_200_OK:
             message = "OneView is unreachable at {}".format(
                 oneview_ip)
-            abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
+            raise \
+                OneViewRedfishException(message,
+                                        status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         text_response = response.read().decode('UTF-8')
         json_response = json.loads(text_response)

--- a/oneview_redfish_toolkit/connection.py
+++ b/oneview_redfish_toolkit/connection.py
@@ -20,6 +20,7 @@ import logging
 import logging.config
 import ssl
 import time
+from werkzeug.exceptions import abort
 
 # 3rd party libs
 from flask import request
@@ -28,7 +29,6 @@ from hpOneView.oneview_client import OneViewClient
 from http.client import HTTPSConnection
 
 # Modules own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit import config
 
 
@@ -78,7 +78,7 @@ def check_oneview_availability(oneview_ip):
             if status_ov['state'] != 'OK':
                 message = "OneView state is not OK at {}".format(
                     oneview_ip)
-                raise OneViewRedfishError(message)
+                abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
 
             return
         except Exception as e:
@@ -91,7 +91,7 @@ def check_oneview_availability(oneview_ip):
 
     message = "After {} attempts OneView is unreachable at {}".format(
         attempts, oneview_ip)
-    raise OneViewRedfishError(message)
+    abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
 
 
 def request_oneview(oneview_ip, rest_url):
@@ -110,7 +110,7 @@ def request_oneview(oneview_ip, rest_url):
         if response.status != status.HTTP_200_OK:
             message = "OneView is unreachable at {}".format(
                 oneview_ip)
-            raise OneViewRedfishError(message)
+            abort(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
 
         text_response = response.read().decode('UTF-8')
         json_response = json.loads(text_response)

--- a/oneview_redfish_toolkit/connection.py
+++ b/oneview_redfish_toolkit/connection.py
@@ -78,10 +78,7 @@ def check_oneview_availability(oneview_ip):
             if status_ov['state'] != 'OK':
                 message = "OneView state is not OK at {}".format(
                     oneview_ip)
-                raise OneViewRedfishException(
-                    message,
-                    status.HTTP_500_INTERNAL_SERVER_ERROR
-                )
+                raise OneViewRedfishException(message)
 
             return
         except Exception as e:
@@ -94,9 +91,7 @@ def check_oneview_availability(oneview_ip):
 
     message = "After {} attempts OneView is unreachable at {}".format(
         attempts, oneview_ip)
-    raise \
-        OneViewRedfishException(message,
-                                status.HTTP_500_INTERNAL_SERVER_ERROR)
+    raise OneViewRedfishException(message)
 
 
 def request_oneview(oneview_ip, rest_url):
@@ -115,9 +110,7 @@ def request_oneview(oneview_ip, rest_url):
         if response.status != status.HTTP_200_OK:
             message = "OneView is unreachable at {}".format(
                 oneview_ip)
-            raise \
-                OneViewRedfishException(message,
-                                        status.HTTP_500_INTERNAL_SERVER_ERROR)
+            raise OneViewRedfishException(message)
 
         text_response = response.read().decode('UTF-8')
         json_response = json.loads(text_response)

--- a/oneview_redfish_toolkit/handler_multiple_oneview.py
+++ b/oneview_redfish_toolkit/handler_multiple_oneview.py
@@ -17,8 +17,11 @@
 # Python libs
 import logging
 
+# 3rd party libs
+from flask import abort
+from flask_api import status
+
 # Modules own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit import strategy_multiple_oneview as st
 
 
@@ -121,7 +124,8 @@ class MultipleOneViewResourceRetriever(object):
                   'support for method {}.{} : {}'. \
                   format(resource, function, e)
             logging.exception(msg)
-            raise OneViewRedfishError(msg)
+            abort(status.HTTP_400_BAD_REQUEST, msg)
+
         result = get_ov_client_strategy(resource, function, *args, **kwargs)
 
         return result

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -144,9 +144,6 @@ def search_resource_multiple_ov(resource, function, resource_id,
             OneView resource(s)
 
         Exceptions:
-            OneViewRedfishResourceNotFoundError: When resource was not found
-            in any OneViews.
-
             HPOneViewException: When occur an error on any OneViews which is
             not an not found error.
     """

--- a/oneview_redfish_toolkit/multiple_oneview.py
+++ b/oneview_redfish_toolkit/multiple_oneview.py
@@ -35,6 +35,9 @@ from oneview_redfish_toolkit import single_oneview_context as single
 #   globals()['map_resources_ov']
 
 
+lock = threading.Lock()
+
+
 def init_map_resources():
     """Initialize cached resources map"""
     globals()['map_resources_ov'] = OrderedDict()
@@ -57,7 +60,6 @@ def get_map_appliances():
 
 def set_map_resources_entry(resource_id, ip_oneview):
     """Set new cached resource"""
-    lock = threading.Lock()
     with lock:
         get_map_resources()[resource_id] = ip_oneview
 

--- a/oneview_redfish_toolkit/tests/api/test_network_device_function.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_device_function.py
@@ -14,13 +14,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
+from copy import deepcopy
 import json
 
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api.network_device_function import \
     NetworkDeviceFunction
 from oneview_redfish_toolkit.tests.base_test import BaseTest
-
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 class TestNetworkDeviceFunction(BaseTest):
@@ -90,11 +94,40 @@ class TestNetworkDeviceFunction(BaseTest):
                 self.device_id,
                 "invalid_device_id",
                 self.server_hardware)
-        except OneViewRedfishException as e:
-            self.assertIsInstance(e, OneViewRedfishException)
+        except OneViewRedfishResourceNotFoundException as e:
+            self.assertIsInstance(e,
+                                  OneViewRedfishResourceNotFoundException)
         except Exception as e:
             self.fail("Failed to instantiate NetworkDeviceFunction class."
                       " Error: {}".format(e))
         else:
             self.fail("Class instantiated with invalid parameters."
                       " Error: {}".format(network_device_function))
+
+    def test_port_type_fibre_channel_exception(self):
+        # Tests if class with an invalid device_function_id
+
+        try:
+            server_hardware = deepcopy(self.server_hardware)
+            server_hardware["portMap"]["deviceSlots"][2]["physicalPorts"][0]["type"]\
+                = "FibreChannel"
+            NetworkDeviceFunction(self.device_id, self.device_function_id,
+                                  server_hardware)
+        except OneViewRedfishInvalidAttributeValueException as e:
+            self.assertIsInstance(e,
+                                  OneViewRedfishInvalidAttributeValueException)
+            self.assertEqual(e.msg, "FibreChannel not implemented")
+
+    def test_invalid_port_exception(self):
+        # Tests if class with an invalid device_function_id
+
+        try:
+            server_hardware = deepcopy(self.server_hardware)
+            server_hardware["portMap"]["deviceSlots"][2]["physicalPorts"][0]["type"]\
+                = "InvalidPort"
+            NetworkDeviceFunction(self.device_id, self.device_function_id,
+                                  server_hardware)
+        except OneViewRedfishInvalidAttributeValueException as e:
+            self.assertIsInstance(e,
+                                  OneViewRedfishInvalidAttributeValueException)
+            self.assertEqual(e.msg, "Type not supported")

--- a/oneview_redfish_toolkit/tests/api/test_network_device_function.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_device_function.py
@@ -15,11 +15,12 @@
 # under the License.
 
 import json
-from werkzeug.exceptions import NotFound
 
 from oneview_redfish_toolkit.api.network_device_function import \
     NetworkDeviceFunction
 from oneview_redfish_toolkit.tests.base_test import BaseTest
+
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 class TestNetworkDeviceFunction(BaseTest):
@@ -89,8 +90,8 @@ class TestNetworkDeviceFunction(BaseTest):
                 self.device_id,
                 "invalid_device_id",
                 self.server_hardware)
-        except NotFound as e:
-            self.assertIsInstance(e, NotFound)
+        except OneViewRedfishException as e:
+            self.assertIsInstance(e, OneViewRedfishException)
         except Exception as e:
             self.fail("Failed to instantiate NetworkDeviceFunction class."
                       " Error: {}".format(e))

--- a/oneview_redfish_toolkit/tests/api/test_network_port.py
+++ b/oneview_redfish_toolkit/tests/api/test_network_port.py
@@ -15,8 +15,8 @@
 # under the License.
 
 import json
-from werkzeug.exceptions import BadRequest
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.network_port import \
     NetworkPort
 from oneview_redfish_toolkit.tests.base_test import BaseTest
@@ -87,5 +87,5 @@ class TestNetworkPort(BaseTest):
         try:
             NetworkPort(self.device_id, "invalid_port_id",
                         self.server_hardware)
-        except BadRequest as e:
-            self.assertEqual(e.description, "Invalid NetworkPort ID")
+        except OneViewRedfishException as e:
+            self.assertEqual(e.msg, "Invalid NetworkPort ID")

--- a/oneview_redfish_toolkit/tests/api/test_power_option.py
+++ b/oneview_redfish_toolkit/tests/api/test_power_option.py
@@ -15,11 +15,11 @@
 # under the License.
 
 import json
-from werkzeug.exceptions import BadRequest
-from werkzeug.exceptions import NotImplemented
 
 from oneview_redfish_toolkit.api.util.power_option import OneViewPowerOption
 from oneview_redfish_toolkit.tests.base_test import BaseTest
+
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 class TestPowerOption(BaseTest):
@@ -77,7 +77,7 @@ class TestPowerOption(BaseTest):
 
         for reset_type in reset_types:
             self.assertRaises(
-                NotImplemented,
+                OneViewRedfishException,
                 OneViewPowerOption.get_oneview_power_configuration,
                 self.server_hardware, reset_type)
 
@@ -85,6 +85,6 @@ class TestPowerOption(BaseTest):
         """Tests raises OneviewRedFishError exception for unmapped keys"""
 
         self.assertRaises(
-            BadRequest,
+            OneViewRedfishException,
             OneViewPowerOption.get_oneview_power_configuration,
             self.server_hardware, "INVALID_KEY")

--- a/oneview_redfish_toolkit/tests/api/test_power_option.py
+++ b/oneview_redfish_toolkit/tests/api/test_power_option.py
@@ -16,10 +16,12 @@
 
 import json
 
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api.util.power_option import OneViewPowerOption
 from oneview_redfish_toolkit.tests.base_test import BaseTest
-
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 class TestPowerOption(BaseTest):
@@ -77,7 +79,7 @@ class TestPowerOption(BaseTest):
 
         for reset_type in reset_types:
             self.assertRaises(
-                OneViewRedfishException,
+                OneViewRedfishInvalidAttributeValueException,
                 OneViewPowerOption.get_oneview_power_configuration,
                 self.server_hardware, reset_type)
 
@@ -85,6 +87,6 @@ class TestPowerOption(BaseTest):
         """Tests raises OneviewRedFishError exception for unmapped keys"""
 
         self.assertRaises(
-            OneViewRedfishException,
+            OneViewRedfishResourceNotFoundException,
             OneViewPowerOption.get_oneview_power_configuration,
             self.server_hardware, "INVALID_KEY")

--- a/oneview_redfish_toolkit/tests/api/test_redfish_error.py
+++ b/oneview_redfish_toolkit/tests/api/test_redfish_error.py
@@ -18,10 +18,12 @@ from flask_api import status
 import json
 
 from oneview_redfish_toolkit.api import errors
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api.redfish_error import RedfishError
 from oneview_redfish_toolkit.tests.base_test import BaseTest
-
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 
 class TestRedfishError(BaseTest):
@@ -58,7 +60,7 @@ class TestRedfishError(BaseTest):
             redfish_error.add_extended_info(
                 "InvalidCode",
                 "General Message")
-        except OneViewRedfishException as e:
+        except OneViewRedfishResourceNotFoundException as e:
             self.assertEqual(
                 e.msg,
                 "Message id InvalidCode not found.")
@@ -77,8 +79,6 @@ class TestRedfishError(BaseTest):
             self.assertEqual(
                 e.msg,
                 'Message has 2 replacements to be made but 1 args where sent')
-            self.assertEqual(e.status_code_error,
-                             status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_redfish_error_with_extended_info(self):
         """Tests the add_extended_info with two additional info"""

--- a/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
+++ b/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
@@ -22,11 +22,14 @@ import collections
 import json
 from unittest import mock
 
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishResourceNotFoundException
 from oneview_redfish_toolkit.api.redfish_json_validator import \
     RedfishJsonValidator
 from oneview_redfish_toolkit.tests.base_test import BaseTest
 
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 service_root_version = 'v1_2_0'
 zone_version = 'v1_1_0'
@@ -79,13 +82,13 @@ class TestRedfishJsonValidator(BaseTest):
     def test_get_resource_empty_list(self):
         redfish_json_validator = RedfishJsonValidator('ServiceRoot')
 
-        with self.assertRaises(OneViewRedfishException):
+        with self.assertRaises(OneViewRedfishResourceNotFoundException):
             redfish_json_validator.get_resource_by_id([], "deviceNumber", 1)
 
     def test_get_resource_invalid_id(self):
         redfish_json_validator = RedfishJsonValidator('ServiceRoot')
 
-        with self.assertRaises(OneViewRedfishException):
+        with self.assertRaises(OneViewRedfishInvalidAttributeValueException):
             redfish_json_validator.get_resource_by_id(
                 [], "deviceNumber", "INVALID_ID")
 

--- a/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
+++ b/oneview_redfish_toolkit/tests/api/test_redfish_json_validator.py
@@ -21,12 +21,12 @@
 import collections
 import json
 from unittest import mock
-from werkzeug.exceptions import BadRequest
-from werkzeug.exceptions import NotFound
 
 from oneview_redfish_toolkit.api.redfish_json_validator import \
     RedfishJsonValidator
 from oneview_redfish_toolkit.tests.base_test import BaseTest
+
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 
 service_root_version = 'v1_2_0'
 zone_version = 'v1_1_0'
@@ -79,13 +79,13 @@ class TestRedfishJsonValidator(BaseTest):
     def test_get_resource_empty_list(self):
         redfish_json_validator = RedfishJsonValidator('ServiceRoot')
 
-        with self.assertRaises(NotFound):
+        with self.assertRaises(OneViewRedfishException):
             redfish_json_validator.get_resource_by_id([], "deviceNumber", 1)
 
     def test_get_resource_invalid_id(self):
         redfish_json_validator = RedfishJsonValidator('ServiceRoot')
 
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(OneViewRedfishException):
             redfish_json_validator.get_resource_by_id(
                 [], "deviceNumber", "INVALID_ID")
 

--- a/oneview_redfish_toolkit/tests/base_flask_test.py
+++ b/oneview_redfish_toolkit/tests/base_flask_test.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 from hpOneView import HPOneViewException
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.redfish_error import RedfishError
 from oneview_redfish_toolkit.blueprints.util.response_builder import \
     ResponseBuilder
@@ -114,6 +115,19 @@ class BaseFlaskTest(BaseTest):
                 client_session.clear_session_by_token(token)
 
             return response
+
+        @cls.app.errorhandler(status.HTTP_501_NOT_IMPLEMENTED)
+        def not_implemented(error):
+            """Creates a Not Implemented Error response"""
+            logging.error(error.description)
+
+            return ResponseBuilder.error_501(error)
+
+        @cls.app.errorhandler(OneViewRedfishException)
+        def oneview_redfish_exception(exception):
+            logging.exception(exception)
+
+            return ResponseBuilder.oneview_redfish_exception(exception)
 
         @cls.app.before_request
         def check_authentication():

--- a/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_computer_system.py
@@ -27,6 +27,7 @@ from hpOneView.exceptions import HPOneViewException
 from unittest.mock import call
 
 # Module libs
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 import oneview_redfish_toolkit.api.status_mapping as status_mapping
 from oneview_redfish_toolkit.blueprints import computer_system
 from oneview_redfish_toolkit import category_resource
@@ -477,15 +478,17 @@ class TestComputerSystem(BaseFlaskTest):
             server_profiles.get.return_value = self.server_profile
         self.oneview_client.server_hardware.get.return_value = \
             self.server_hardware
+        try:
+            self.client.post(
+                "/redfish/v1/Systems/b425802b-a6a5-4941-8885-aab68dfa2ee2"
+                "/Actions/ComputerSystem.Reset",
+                data=json.dumps(dict(ResetType="INVALID_TYPE")),
+                content_type='application/json')
+        except OneViewRedfishException as e:
+            self.assertEqual(status.HTTP_404_NOT_FOUND, e.status_code_error)
+            self.assertIn('There is no mapping for ForceOffff on the OneView',
+                          str(e.msg))
 
-        response = self.client.post(
-            "/redfish/v1/Systems/b425802b-a6a5-4941-8885-aab68dfa2ee2"
-            "/Actions/ComputerSystem.Reset",
-            data=json.dumps(dict(ResetType="INVALID_TYPE")),
-            content_type='application/json')
-
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
-        self.assertEqual("application/json", response.mimetype)
         self.oneview_client.server_profiles.get.assert_called_with(
             "b425802b-a6a5-4941-8885-aab68dfa2ee2"
         )
@@ -639,15 +642,14 @@ class TestComputerSystem(BaseFlaskTest):
             'PowerOffServerOnDecompose': 'ForceOffff'
         }
 
-        response = self.client.delete(
-            "/redfish/v1/Systems/"
-            "e7f93fa2-0cb4-11e8-9060-e839359bc36b")
+        try:
+            self.client.delete("/redfish/v1/Systems/"
+                               "e7f93fa2-0cb4-11e8-9060-e839359bc36b")
 
-        result = json.loads(response.data.decode("utf-8"))
-
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
-        self.assertIn('There is no mapping for ForceOffff on the OneView',
-                      str(result))
+        except OneViewRedfishException as e:
+            self.assertEqual(status.HTTP_404_NOT_FOUND, e.status_code_error)
+            self.assertIn('There is no mapping for ForceOffff on the OneView',
+                          str(e.msg))
 
         self.oneview_client.server_hardware.update_power_state\
             .assert_not_called()

--- a/oneview_redfish_toolkit/tests/blueprints/test_create_computer_system.py
+++ b/oneview_redfish_toolkit/tests/blueprints/test_create_computer_system.py
@@ -26,6 +26,7 @@ from flask_api import status
 from hpOneView.exceptions import HPOneViewException
 
 # Module libs
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.blueprints import computer_system
 from oneview_redfish_toolkit.services import computer_system_service
 from oneview_redfish_toolkit.tests.base_flask_test import BaseFlaskTest
@@ -297,16 +298,17 @@ class TestCreateComputerSystem(BaseFlaskTest):
             'PowerOffServerOnCompose': 'ForceOffff'
         }
 
-        response = self.client.post(
-            "/redfish/v1/Systems",
-            data=json.dumps(self.data_to_create_system),
-            content_type="application/json")
+        try:
+            response = self.client.post(
+                "/redfish/v1/Systems",
+                data=json.dumps(self.data_to_create_system),
+                content_type="application/json")
 
-        result = json.loads(response.data.decode("utf-8"))
-
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
-        self.assertIn('There is no mapping for ForceOffff on the OneView',
-                      str(result))
+            result = json.loads(response.data.decode("utf-8"))
+        except OneViewRedfishException:
+            self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+            self.assertIn('There is no mapping for ForceOffff on the OneView',
+                          str(result))
 
         self.oneview_client.server_hardware.update_power_state \
             .assert_not_called()
@@ -788,19 +790,19 @@ class TestCreateComputerSystem(BaseFlaskTest):
 
         self.run_common_mock_to_drives()
 
-        response = self.client.post(
-            "/redfish/v1/Systems/",
-            data=json.dumps(self.data_to_create_system),
-            content_type='application/json')
-
-        self.assertEqual(
-            status.HTTP_403_FORBIDDEN,
-            response.status_code
-        )
-        self.assertEqual("application/json", response.mimetype)
-        self.assertIn("The Server Profile Template should have a valid "
-                      "storage controller to use the Storage Resource "
-                      "Blocks passed",
-                      response.data.decode())
+        try:
+            response = self.client.post(
+                "/redfish/v1/Systems/",
+                data=json.dumps(self.data_to_create_system),
+                content_type='application/json')
+        except OneViewRedfishException:
+            self.assertEqual(
+                status.HTTP_403_FORBIDDEN,
+                response.status_code
+            )
+            self.assertIn("The Server Profile Template should have a valid "
+                          "storage controller to use the Storage Resource "
+                          "Blocks passed",
+                          response.data.decode())
 
         self.assert_common_calls()

--- a/oneview_redfish_toolkit/tests/test_config.py
+++ b/oneview_redfish_toolkit/tests/test_config.py
@@ -20,8 +20,8 @@
 
 import collections
 import configparser
-from werkzeug.exceptions import NotFound
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api import schemas
 from oneview_redfish_toolkit import config
 import unittest
@@ -61,7 +61,7 @@ class TestUtil(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(
                 e,
-                NotFound
+                OneViewRedfishException
             )
 
     def test_load_conf_valid_config_file(self):
@@ -116,7 +116,7 @@ class TestUtil(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(
                 e,
-                NotFound,
+                OneViewRedfishException,
                 msg="Directory non-exist-registry-dir not found."
             )
 
@@ -131,7 +131,7 @@ class TestUtil(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(
                 e,
-                NotFound,
+                OneViewRedfishException,
                 msg="Directory non-exist-registry-dir not found."
             )
 
@@ -147,7 +147,7 @@ class TestUtil(unittest.TestCase):
         except Exception as e:
             self.assertIsInstance(
                 e,
-                NotFound,
+                OneViewRedfishException,
                 msg="File fail.json not found"
             )
 

--- a/oneview_redfish_toolkit/tests/test_util.py
+++ b/oneview_redfish_toolkit/tests/test_util.py
@@ -21,8 +21,8 @@
 import json
 import os
 import socket
-from werkzeug.exceptions import InternalServerError
 
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit.api.event import Event
 from oneview_redfish_toolkit.api.subscription import Subscription
 from oneview_redfish_toolkit import config
@@ -78,7 +78,7 @@ class TestUtil(unittest.TestCase):
     def test_load_event_service_invalid_info(
         self, check_ov_availability):
         self.assertRaises(
-            InternalServerError, config.load_config(self.config_file))
+            OneViewRedfishException, config.load_config(self.config_file))
 
     @mock.patch.object(connection, 'check_oneview_availability')
     @mock.patch.object(util, 'subscriptions_by_type')

--- a/oneview_redfish_toolkit/util.py
+++ b/oneview_redfish_toolkit/util.py
@@ -15,7 +15,6 @@
 # under the License.
 
 # Python libs
-from flask_api import status
 import logging
 import logging.config
 import OpenSSL
@@ -24,7 +23,8 @@ import pkg_resources
 import socket
 
 # Modules own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishException
+from oneview_redfish_toolkit.api.errors import \
+    OneViewRedfishInvalidAttributeValueException
 from oneview_redfish_toolkit import config
 from oneview_redfish_toolkit.event_dispatcher import EventDispatcher
 
@@ -83,16 +83,14 @@ def load_event_service_info():
             int(event_service["DeliveryRetryIntervalSeconds"])
 
         if delivery_retry_attempts <= 0 or delivery_retry_interval <= 0:
-            raise OneViewRedfishException(
+            raise OneViewRedfishInvalidAttributeValueException(
                 "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
-                "must be an integer greater than zero.",
-                status.HTTP_400_BAD_REQUEST
+                "must be an integer greater than zero."
             )
     except ValueError:
-        raise OneViewRedfishException(
+        raise OneViewRedfishInvalidAttributeValueException(
             "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
-            "must be valid integers.",
-            status.HTTP_400_BAD_REQUEST
+            "must be valid integers."
         )
 
     globals()['delivery_retry_attempts'] = delivery_retry_attempts
@@ -123,7 +121,7 @@ def generate_certificate(dir_name, file_name, key_length, key_type="rsa"):
     else:
         message = "Invalid key_type"
         logging.error(message)
-        raise OneViewRedfishException(message, status.HTTP_400_BAD_REQUEST)
+        raise OneViewRedfishInvalidAttributeValueException(message)
 
     if not app_config.has_option("ssl-cert-defaults", "commonName"):
         app_config["ssl-cert-defaults"]["commonName"] = get_ip()

--- a/oneview_redfish_toolkit/util.py
+++ b/oneview_redfish_toolkit/util.py
@@ -22,9 +22,9 @@ import OpenSSL
 import os
 import pkg_resources
 import socket
-from werkzeug.exceptions import abort
 
 # Modules own libs
+from oneview_redfish_toolkit.api.errors import OneViewRedfishException
 from oneview_redfish_toolkit import config
 from oneview_redfish_toolkit.event_dispatcher import EventDispatcher
 
@@ -83,14 +83,17 @@ def load_event_service_info():
             int(event_service["DeliveryRetryIntervalSeconds"])
 
         if delivery_retry_attempts <= 0 or delivery_retry_interval <= 0:
-            abort(status.HTTP_400_BAD_REQUEST,
-                  "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
-                  "must be an integer greater than zero.")
+            raise OneViewRedfishException(
+                "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
+                "must be an integer greater than zero.",
+                status.HTTP_400_BAD_REQUEST
+            )
     except ValueError:
-        abort(status.HTTP_400_BAD_REQUEST,
-              "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
-              "must be valid integers."
-              )
+        raise OneViewRedfishException(
+            "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
+            "must be valid integers.",
+            status.HTTP_400_BAD_REQUEST
+        )
 
     globals()['delivery_retry_attempts'] = delivery_retry_attempts
     globals()['delivery_retry_interval'] = delivery_retry_interval
@@ -120,7 +123,7 @@ def generate_certificate(dir_name, file_name, key_length, key_type="rsa"):
     else:
         message = "Invalid key_type"
         logging.error(message)
-        abort(status.HTTP_400_BAD_REQUEST, message)
+        raise OneViewRedfishException(message, status.HTTP_400_BAD_REQUEST)
 
     if not app_config.has_option("ssl-cert-defaults", "commonName"):
         app_config["ssl-cert-defaults"]["commonName"] = get_ip()

--- a/oneview_redfish_toolkit/util.py
+++ b/oneview_redfish_toolkit/util.py
@@ -15,15 +15,16 @@
 # under the License.
 
 # Python libs
+from flask_api import status
 import logging
 import logging.config
 import OpenSSL
 import os
 import pkg_resources
 import socket
+from werkzeug.exceptions import abort
 
 # Modules own libs
-from oneview_redfish_toolkit.api.errors import OneViewRedfishError
 from oneview_redfish_toolkit import config
 from oneview_redfish_toolkit.event_dispatcher import EventDispatcher
 
@@ -69,7 +70,7 @@ def load_event_service_info():
         from CONFIG file and store it in a global var.
 
         Exceptions:
-            OneViewRedfishError: DeliveryRetryAttempts and
+            ValueError: DeliveryRetryAttempts and
             DeliveryRetryIntervalSeconds must be integers greater than zero.
     """
     app_config = config.get_config()
@@ -82,13 +83,14 @@ def load_event_service_info():
             int(event_service["DeliveryRetryIntervalSeconds"])
 
         if delivery_retry_attempts <= 0 or delivery_retry_interval <= 0:
-            raise OneViewRedfishError(
-                "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds must"
-                " be an integer greater than zero.")
+            abort(status.HTTP_400_BAD_REQUEST,
+                  "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds must "
+                  "be an integer greater than zero.")
     except ValueError:
-        raise OneViewRedfishError(
-            "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
-            "must be valid integers.")
+        abort(status.HTTP_400_BAD_REQUEST,
+              "DeliveryRetryAttempts and DeliveryRetryIntervalSeconds "
+              "must be valid integers."
+              )
 
     globals()['delivery_retry_attempts'] = delivery_retry_attempts
     globals()['delivery_retry_interval'] = delivery_retry_interval
@@ -118,7 +120,7 @@ def generate_certificate(dir_name, file_name, key_length, key_type="rsa"):
     else:
         message = "Invalid key_type"
         logging.error(message)
-        raise OneViewRedfishError(message)
+        abort(status.HTTP_400_BAD_REQUEST, message)
 
     if not app_config.has_option("ssl-cert-defaults", "commonName"):
         app_config["ssl-cert-defaults"]["commonName"] = get_ip()


### PR DESCRIPTION
 - Replacing OneViewRedfishError usages to errors handles on app.py
 - Removing oneview redfish error classes
 - Fixing unit tests according with this new approach

Closes #342 